### PR TITLE
Java 8 by default for Mendix 5.18+

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -21,6 +21,7 @@ BUILDPACK_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 
 sys.path.insert(0, os.path.join(BUILDPACK_DIR, 'lib'))
 import buildpackutil
+from m2ee.version import MXVersion
 import requests
 
 logging.getLogger("requests").setLevel(logging.WARNING)
@@ -31,7 +32,11 @@ def _get_java_version():
         '7': '7u80',
         '8': '8u45',
     }
-    main_java_version = os.getenv('JAVA_VERSION', '7')
+    if get_runtime_version() >= 5.18:
+        default = '8'
+    else:
+        default = '7'
+    main_java_version = os.getenv('JAVA_VERSION', default)
 
     if main_java_version not in versions.keys():
         raise Exception(
@@ -102,10 +107,11 @@ def mkdir_p(path):
             raise
 
 
-def parse_runtime_version(file_name):
+def get_runtime_version():
+    file_name = os.path.join(BUILD_DIR, 'model', 'metadata.json')
     with open(file_name) as file_handle:
         data = json.loads(file_handle.read())
-        return data['RuntimeVersion']
+        return MXVersion(data['RuntimeVersion'])
 
 
 def check_environment_variable(variable, explanation):
@@ -195,10 +201,9 @@ def download_mendix_version():
     url = os.environ.get('FORCED_MXRUNTIME_URL')
     if url is None:
         use_cache = True
-        version = parse_runtime_version(
-            os.path.join(BUILD_DIR, 'model', 'metadata.json')
+        url = 'http://cdn.mendix.com/runtime/mendix-%s.tar.gz' % str(
+            get_runtime_version()
         )
-        url = 'http://cdn.mendix.com/runtime/mendix-%s.tar.gz' % version
     else:
         use_cache = False
     download_and_unpack(


### PR DESCRIPTION
also use MXVersion in bin/compile which is nice
