### PR TITLE
fix(m2ee/config.py) remove WARNING: Mendix Runtime not found for version

### DIFF
--- a/lib/m2ee/config.py
+++ b/lib/m2ee/config.py
@@ -82,10 +82,6 @@ class M2EEConfig:
                 self._runtime_path = self.lookup_in_mxjar_repo(
                     str(self.runtime_version))
                 if self._runtime_path is None:
-                    logger.warn("Mendix Runtime not found for version %s. "
-                                "You can try downloading it using the "
-                                "download_runtime command." %
-                                str(self.runtime_version))
                     self._all_systems_are_go = False
 
         self._setup_classpath()


### PR DESCRIPTION
We need to fix this properly at a later time. However, since the M2EE
lib here is currently a copy, this is the most pragmatic way to remove
this warning, which is probably confusing for the users of our buildpack.
The warning is a valid thing (because at that point in time, there is
no Mendix Runtime), however, start.py takes care of ensuring the
Mendix Runtime is actually in place before we actually start the app.