### PR TITLE
Revert a53dd73e "use target=deploy for mxbuild"

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -4,6 +4,7 @@ import sys
 import json
 import shutil
 import logging
+import zipfile
 import subprocess
 
 BUILD_DIR = sys.argv[1]
@@ -227,7 +228,8 @@ def run_mx_build():
         os.path.join(mono_location, 'bin/mono'),
         '--config', os.path.join(mono_location, 'etc/mono/config'),
         os.path.join(mxbuild_location, 'modeler/mxbuild.exe'),
-        '--target=deploy',
+        '--target=package',
+        '--output=/tmp/model.mda',
         '--java-home=%s' % jdk_location,
         '--java-exe-path=%s' % os.path.join(jdk_location, 'bin/java'),
     ]
@@ -251,18 +253,18 @@ def run_mx_build():
         buildstatus_callback(BUILD_ERRORS_JSON)
         raise e
 
-    for dir_name in ['web', 'model']:
-        path = os.rename(
-            os.path.join(BUILD_DIR, 'deployment', dir_name),
-            os.path.join(BUILD_DIR, dir_name),
-        )
     for file_name in os.listdir(BUILD_DIR):
         path = os.path.join(BUILD_DIR, file_name)
-        if file_name not in ['.local', 'web', 'model']:
+        if file_name != '.local':
             if os.path.isdir(path):
                 shutil.rmtree(path)
             else:
                 os.unlink(path)
+    zf = zipfile.ZipFile('/tmp/model.mda')
+    try:
+        zf.extractall(BUILD_DIR)
+    finally:
+        zf.close()
 
 
 def buildstatus_callback(error_file):

--- a/tests/usecase/test_sampledata.py
+++ b/tests/usecase/test_sampledata.py
@@ -1,0 +1,27 @@
+import basetest
+import subprocess
+import requests
+import json
+
+
+class TestCaseSampleData(basetest.BaseTest):
+
+    def setUp(self):
+        self.setUpCF('MontBlancApp671WithSampleData.mpk')
+        subprocess.check_call(('cf', 'start', self.app_name))
+
+    def test_user_from_sampledata_can_log_in(self):
+        full_uri = "https://" + self.app_name + "/xas/"
+        login_action = {
+            'action': 'login',
+            'params': {
+                'username': 'henk',
+                'password': 'henkie',
+            },
+        }
+        r = requests.post(
+            full_uri,
+            headers={'Content-Type': 'application/json'},
+            data=json.dumps(login_action),
+        )
+        assert r.status_code == 200


### PR DESCRIPTION
target=deploy does not include sampledata, but does specify it in
metadata.json so the app refuses to start afterwards

modeler team will either fix target=deploy or introduce target=package
--no-zip so we can start re-using the zip/unzip optimization