### PR TITLE
fastdeploy: if build contains errors, don't restart

### DIFF
--- a/tests/usecase/test_fastdeploy.py
+++ b/tests/usecase/test_fastdeploy.py
@@ -18,5 +18,7 @@ class TestCaseFastdeploy(basetest.BaseTest):
         r = requests.post(full_uri, auth=('deploy', self.mx_password), files={
             'file': open('MontBlancApp671b.mpk', 'rb'),
         })
+        if r.status_code != 200:
+            print r.text
         assert r.status_code == 200
         assert "STARTED" in r.text


### PR DESCRIPTION
also return a FAILED state so the WM knows there were errors