### PR TITLE
690250 critical logs

### DIFF
--- a/lib/metrics.py
+++ b/lib/metrics.py
@@ -14,17 +14,20 @@ class MetricsEmitterThread(threading.Thread):
     def run(self):
         logger.debug('Starting metrics emitter with interval %d' % self.interval)
         while True:
-            m2ee_stats, java_version = munin.get_stats_from_runtime(self.m2ee.client, self.m2ee.config)
-            m2ee_stats = munin.augment_and_fix_stats(
-                m2ee_stats,
-                self.m2ee.runner.get_pid(),
-                java_version)
-            critical_logs_count = len(self.m2ee.client.get_critical_log_messages())
-            m2ee_stats['critical_logs_count'] = critical_logs_count
-            stats = {
-                'version': '1.0',
-                'timestamp': datetime.datetime.now().isoformat(),
-                'mendix_runtime': m2ee_stats,
-            }
-            logger.info('MENDIX-METRICS: ' + json.dumps(stats))
+            try:
+                m2ee_stats, java_version = munin.get_stats_from_runtime(self.m2ee.client, self.m2ee.config)
+                m2ee_stats = munin.augment_and_fix_stats(
+                    m2ee_stats,
+                    self.m2ee.runner.get_pid(),
+                    java_version)
+                critical_logs_count = len(self.m2ee.client.get_critical_log_messages())
+                m2ee_stats['critical_logs_count'] = critical_logs_count
+                stats = {
+                    'version': '1.0',
+                    'timestamp': datetime.datetime.now().isoformat(),
+                    'mendix_runtime': m2ee_stats,
+                }
+                logger.info('MENDIX-METRICS: ' + json.dumps(stats))
+            except Exception as e:
+                logger.warn('Failed to emit Mendix runtime metrics: ' + str(e))
             time.sleep(self.interval)

--- a/lib/metrics.py
+++ b/lib/metrics.py
@@ -19,6 +19,8 @@ class MetricsEmitterThread(threading.Thread):
                 m2ee_stats,
                 self.m2ee.runner.get_pid(),
                 java_version)
+            critical_logs_count = len(self.m2ee.client.get_critical_log_messages())
+            m2ee_stats['critical_logs_count'] = critical_logs_count
             stats = {
                 'version': '1.0',
                 'timestamp': datetime.datetime.now().isoformat(),

--- a/tests/usecase/test_emit_metrics.py
+++ b/tests/usecase/test_emit_metrics.py
@@ -13,3 +13,4 @@ class TestCaseEmitMetrics(basetest.BaseTest):
     def test_read_metrics_in_logs(self):
         time.sleep(10)
         self.assert_string_in_recent_logs(self.app_name, 'MENDIX-METRICS: ')
+        self.assert_string_in_recent_logs(self.app_name, 'critical_logs_count')


### PR DESCRIPTION
Introduce critical log message count in MENDIX-METRICS

* 	emit critical log message count within MENDIX-METRICS
* 	prevent emitter thread from exiting on exceptions