### PR TITLE
S949507: paid apps use rds as database service

### DIFF
--- a/lib/metrics.py
+++ b/lib/metrics.py
@@ -76,7 +76,10 @@ class MetricsEmitterThread(threading.Thread):
     def _get_pg_conn(self):
         vcap_services = buildpackutil.get_vcap_services_data()
         try:
-            uri = vcap_services['PostgreSQL'][0]['credentials']['uri']
+            if 'rds' in vcap_services:
+                uri = vcap_services['rds'][0]['credentials']['uri']
+            else:
+                uri = vcap_services['PostgreSQL'][0]['credentials']['uri']
             result = urlparse.urlparse(uri)
             username = result.username
             password = result.password

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -23,4 +23,4 @@ virtualenv -p python2 venv
 pip install -r requirements.txt
 
 
-python venv/bin/nosetests -vv --processes=4 --process-timeout=600 usecase/
+python venv/bin/nosetests -vv --processes=3 --process-timeout=600 usecase/


### PR DESCRIPTION
Paid apps use RDS:

```json
  "rds": [
   {
    "credentials": {
     "db_name": "somename",
     "host": "somehost.eu-west-1.rds.amazonaws.com",
     "password": "somepasswd",
   ...
    },
```

```
2016-10-14T18:33:01.81+0200 [App/0]      ERR ERROR: MENDIX-METRICS: PostgreSQL
```