### PR TITLE
remove mx6 cluster option

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ If the setting contains a dot `.` you can use an underscore `_` in the environme
 
 ### Horizontal Scaling
 
-There are two ways for horizontal scaling in Mendix. In Mendix 5.15+ you can use sticky sessions. Mendix 6 has Cluster Support (BETA) using a REDIS instance as state store. Mendix 7 brings this even further by no longer requiring a state store. See below on how to activate these settings, based on the Mendix version you use.
+There are two ways for horizontal scaling in Mendix. In Mendix 5.15+ you can use sticky sessions. Mendix 7 brings this even further by no longer requiring a state store. See below on how to activate these settings, based on the Mendix version you use.
 
 #### Things to keep in mind when scaling horizontally
 
@@ -151,21 +151,11 @@ When using sticky sessions, clients need to support http cookies. Webservice int
 
 With sticky sessions there is an increase in resiliency. If one instance crashes, only 1/n-th of the users will be affected. These users will lose their session state and will have to sign in again.
 
-#### Configuring Cluster Support (BETA feature for Mendix 6)
-
-With Mendix 6 it is possible to configure clustering support. With clustering support it is possible to run multiple instances of your application to achieve High Availability. Clustering support can be enabled by setting the environment variable `CLUSTER_ENABLED` to `true`.
-
-To optimize performance it is possible to choose for REDIS as State Storage. To use that, add the `RedisCloud` service to your application and configure Mendix to use REDIS for State Storage by setting the environment variable `CLUSTER_STATE_IMPLEMENTATION` to `redis`. In case your selected REDIS service has limited connections available, configure the maximum amount of connections that REDIS can allocate per Mendix Business Server instance by setting the environment variable `CLUSTER_STATE_REDIS_MAX_CONNECTIONS` to the amount of connections available in your plan divided by the amount of instances you want to run.
-
-NOTE: Clustering support is a BETA feature and as such not supported by Mendix for production usage. Settings and implementations may be changed in future releases!
-
-NOTE: Enabling clustering support will automatically disable sticky sessions
-
 #### Configuring Clustering for Mendix 7
 
-Mendix 7 does no longer require a state store like Mendix 6. This makes it easier to scale out and has better performance compared to Mendix 6. The absence of the need for a state store results in the fact that nothing needs to be configured for running Mendix 7 in clustering mode. Based on the `CF_INSTANCE_INDEX` variable, the runtime starts either in leader or slave mode. The leader mode will do the database synchronization activities (when necessary), while the slaves will automatically wait until that is finished.
+Mendix 7 makes it easier to scale out. The absence of the need for a state store results in the fact that nothing needs to be configured for running Mendix 7 in clustering mode. Based on the `CF_INSTANCE_INDEX` variable, the runtime starts either in leader or slave mode. The leader mode will do the database synchronization activities (when necessary), while the slaves will automatically wait until that is finished.
 
-NOTE: The setting `CLUSTER_ENABLED` and the REDIS related settings will have no effect anymore in Mendix 7 and are ignored.
+NOTE: The previously documented setting `CLUSTER_ENABLED` and the REDIS related settings for Mendix 6 will have no effect anymore in Mendix 7 and are ignored.
 
 ### Offline buildpack settings
 

--- a/start.py
+++ b/start.py
@@ -153,7 +153,7 @@ def activate_license():
 
 def get_scheduled_events(metadata):
     scheduled_events = os.getenv('SCHEDULED_EVENTS', None)
-    if not am_i_primary_instance():
+    if not i_am_primary_instance():
         logger.debug(
             'Disabling all scheduled events because I am not the primary '
             'instance'
@@ -321,10 +321,6 @@ def get_filestore_config(m2ee):
         return config
 
 
-def is_cluster_leader():
-    return os.getenv('CF_INSTANCE_INDEX', '0') == '0'
-
-
 def get_certificate_authorities():
     config = {}
     cas = os.getenv('CERTIFICATE_AUTHORITIES', None)
@@ -423,7 +419,7 @@ def set_runtime_config(metadata, mxruntime_config, vcap_data, m2ee):
         app_config['DTAPMode'] = 'D'
 
     if (m2ee.config.get_runtime_version() >= 7 and
-            not is_cluster_leader()):
+            not i_am_primary_instance()):
         app_config['com.mendix.core.isClusterSlave'] = 'true'
     elif (m2ee.config.get_runtime_version() >= 5.15 and
             os.getenv('ENABLE_STICKY_SESSIONS', 'false').lower() == 'true'):
@@ -639,7 +635,7 @@ def start_app(m2ee):
                 logger.warning('DB does not exists')
                 abort = True
             elif result == 3:
-                if am_i_primary_instance():
+                if i_am_primary_instance():
                     if os.getenv('SHOW_DDL_COMMANDS', '').lower() == 'true':
                         for line in m2ee.client.get_ddl_commands({
                             "verbose": True
@@ -762,7 +758,7 @@ def loop_until_process_dies(m2ee):
     sys.exit(1)
 
 
-def am_i_primary_instance():
+def i_am_primary_instance():
     return os.getenv('CF_INSTANCE_INDEX', '0') == '0'
 
 


### PR DESCRIPTION
This was a beta release and we move all the state to the client in Mendix 7. Let's remove this option to keep the buildpack simpler.