### PR TITLE
app user / admin port can have different passwords

### DIFF
--- a/start.py
+++ b/start.py
@@ -675,8 +675,12 @@ def start_app(m2ee):
 def create_admin_user(m2ee):
     logger.info('Ensuring admin user credentials')
     logger.debug('Creating admin user')
+    app_admin_password = os.getenv(
+        'APP_ADMIN_PASSWORD',
+        os.getenv('ADMIN_PASSWORD')
+    )
     m2eeresponse = m2ee.client.create_admin_user({
-        'password': os.environ.get('ADMIN_PASSWORD'),
+        'password': app_admin_password
     })
     if m2eeresponse.has_error():
         m2eeresponse.display_error()
@@ -686,7 +690,7 @@ def create_admin_user(m2ee):
     logger.debug('Setting admin user password')
     m2eeresponse = m2ee.client.create_admin_user({
         'username': m2ee.config._model_metadata['AdminUser'],
-        'password': os.environ.get('ADMIN_PASSWORD'),
+        'password': app_admin_password
     })
     if m2eeresponse.has_error():
         m2eeresponse.display_error()


### PR DESCRIPTION
if you want a different admin user password within the app, you can use
the APP_ADMIN_PASSWORD user. The /_mxbuild/ m2ee api will have the
ADMIN_PASSWORD value. This is not exposed to customers and thus not
documented, but we'll use it in the Mendix Cloud