### PR TITLE
add instance_index to metrics emitter

### DIFF
--- a/lib/metrics.py
+++ b/lib/metrics.py
@@ -30,6 +30,7 @@ class MetricsEmitterThread(threading.Thread):
             stats = {
                 'version': '1.0',
                 'timestamp': datetime.datetime.now().isoformat(),
+                'instance_index': os.getenv('CF_INSTANCE_INDEX'),
             }
             stats = self._inject_m2ee_stats(stats)
             stats = self._inject_storage_stats(stats)


### PR DESCRIPTION
Not defaulting to 0 here, it will mess with the data