### PR TITLE
for multiple instances, only emit database stats on first instance

### DIFF
--- a/lib/buildpackutil.py
+++ b/lib/buildpackutil.py
@@ -359,3 +359,7 @@ def ensure_and_return_java_sdk(mx_version, cache_dir):
         '/usr/lib/jvm/jdk-%s-oracle-x64' % java_version,
         '/tmp/javasdk/usr/lib/jvm/jdk-%s-oracle-x64' % java_version,
     ], 'Java not found')
+
+
+def i_am_primary_instance():
+    return os.getenv('CF_INSTANCE_INDEX', '0') == '0'

--- a/lib/metrics.py
+++ b/lib/metrics.py
@@ -32,8 +32,9 @@ class MetricsEmitterThread(threading.Thread):
                 'timestamp': datetime.datetime.now().isoformat(),
             }
             stats = self._inject_m2ee_stats(stats)
-            stats = self._inject_storage_stats(stats)
-            stats = self._inject_database_stats(stats)
+            if buildpackutil.i_am_primary_instance():
+                stats = self._inject_storage_stats(stats)
+                stats = self._inject_database_stats(stats)
 
             logger.info('MENDIX-METRICS: ' + json.dumps(stats))
 

--- a/start.py
+++ b/start.py
@@ -15,6 +15,7 @@ import logging
 import fastdeploy
 import metrics
 from nginx import get_path_config, gen_htpasswd
+from buildpackutil import i_am_primary_instance
 
 logger.setLevel(buildpackutil.get_buildpack_loglevel())
 
@@ -760,10 +761,6 @@ def loop_until_process_dies(m2ee):
             break
     logger.info('process died, stopping')
     sys.exit(1)
-
-
-def i_am_primary_instance():
-    return os.getenv('CF_INSTANCE_INDEX', '0') == '0'
 
 
 def set_up_fastdeploy_if_deploy_password_is_set(m2ee):


### PR DESCRIPTION
else this leads to a lot of duplication in our metrics services and this data is identical for all instances