### PR TITLE
fixes fallback condition where VCAP_SERVICES is not found

### DIFF
--- a/lib/buildpackutil.py
+++ b/lib/buildpackutil.py
@@ -67,7 +67,7 @@ def get_vcap_services_data():
     if os.environ.get('VCAP_SERVICES'):
         return json.loads(os.environ.get('VCAP_SERVICES'))
     else:
-        return None
+        return {}
 
 
 def get_database_uri_from_vcap():

--- a/start.py
+++ b/start.py
@@ -303,8 +303,6 @@ def _get_swift_specific_config(vcap_services, m2ee):
 
 def get_filestore_config(m2ee):
     vcap_services = buildpackutil.get_vcap_services_data()
-    if vcap_services is None:
-        vcap_services = {}
 
     config = _get_s3_specific_config(vcap_services, m2ee)
 


### PR DESCRIPTION
This was defaulting to None but None is not iterable so the following block of
get_database_url_from_vcap() (lib/buildpack.py:77) crashes.