### PR TITLE
switch to mono4 when mx >= 7.0.2

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -197,7 +197,7 @@ def is_source_push():
 
 
 def run_mx_build():
-    mx_version = str(get_runtime_version())
+    mx_version = get_runtime_version()
     mono_location = buildpackutil.ensure_and_get_mono(mx_version, CACHE_DIR)
     logging.debug('Mono available: {mono_location}'.format(mono_location=mono_location))
     mono_env = buildpackutil._get_env_with_monolib(mono_location)
@@ -205,11 +205,11 @@ def run_mx_build():
     mxbuild_location = os.path.join(DOT_LOCAL_LOCATION, 'mxbuild')
 
     buildpackutil.ensure_mxbuild_in_directory(
-        mxbuild_location, get_runtime_version(), CACHE_DIR
+        mxbuild_location, mx_version, CACHE_DIR
     )
 
     jdk_location = buildpackutil.ensure_and_return_java_sdk(
-        get_runtime_version(), CACHE_DIR
+        mx_version, CACHE_DIR
     )
 
     buildpackutil.lazy_remove_file(BUILD_ERRORS_JSON)
@@ -224,7 +224,7 @@ def run_mx_build():
         '--java-exe-path=%s' % os.path.join(jdk_location, 'bin/java'),
     ]
 
-    if get_runtime_version() >= 6.4 or os.environ.get('FORCE_WRITE_BUILD_ERRORS'):
+    if mx_version >= 6.4 or os.environ.get('FORCE_WRITE_BUILD_ERRORS'):
         args.append('--write-errors=%s' % BUILD_ERRORS_JSON)
         logging.debug('Will write build errors to %s' % BUILD_ERRORS_JSON)
 

--- a/lib/buildpackutil.py
+++ b/lib/buildpackutil.py
@@ -129,7 +129,7 @@ def download_and_unpack(url, destination, cache_dir='/tmp/downloads'):
         ))
 
     logging.debug('extracting: {cached_location} to {dest}'.format(
-        cached_location=cached_location,dest=destination ))
+        cached_location=cached_location, dest=destination))
     if file_name.endswith('.deb'):
         subprocess.check_call(
             ['dpkg-deb', '-x', cached_location, destination]
@@ -287,12 +287,23 @@ def _get_env_with_monolib(mono_dir):
     return env
 
 
-def _detect_mono_version():
-    if os.environ.get('FORCED_MONO4_VERSION'):
-        logging.warning('Using forced mono version')
-        target = 'mono-4.4.1.0'
-    else:
+def _detect_mono_version(mx_version):
+    must_use_mono3 = [
+        '7-build14176',
+        '7-build14154',
+        '7-build13112',
+        '7.0.0-alpha2',
+        '7.0.0',
+        '7.0.0-webmodeler',
+        '7.0.1',
+        '7.0.1-webmodeler',
+    ]
+    logging.debug('Detecting Mono Runtime using mendix version: ' + str(mx_version))
+
+    if str(mx_version) in must_use_mono3 or mx_version < 7:
         target = 'mono-3.10.0'
+    else:
+        target = 'mono-4.6.2.16'
     logging.info('Selecting Mono Runtime: ' + target)
     return target
 
@@ -315,9 +326,9 @@ def lazy_remove_file(filename):
 
 def ensure_and_get_mono(mx_version, cache_dir):
     logging.debug('ensuring mono for mendix {mx_version}'.format(
-        mx_version=mx_version
+        mx_version=str(mx_version)
     ))
-    mono_version = _detect_mono_version()
+    mono_version = _detect_mono_version(mx_version)
     fallback_location = '/tmp/opt'
     try:
         mono_location = _get_mono_path('/tmp/opt', mono_version)

--- a/tests/usecase/basetest.py
+++ b/tests/usecase/basetest.py
@@ -69,6 +69,9 @@ class BaseTest(unittest.TestCase):
         r = requests.get(full_uri)
         assert r.status_code == code
 
+    def get_recent_logs(self):
+        return unicode(subprocess.check_output(('cf', 'logs', self.app_name, '--recent')), 'utf-8')
+
     def assert_string_in_recent_logs(self, app_name, substring):
         output = subprocess.check_output(('cf', 'logs', app_name, '--recent'))
         if output.find(substring) > 0:

--- a/tests/usecase/basetest.py
+++ b/tests/usecase/basetest.py
@@ -25,7 +25,11 @@ class BaseTest(unittest.TestCase):
         self.mx_password = os.environ.get("MX_PASSWORD", "Y0l0lop13#123")
 
     def startApp(self):
-        subprocess.check_call(('cf', 'start', self.app_name))
+        try:
+            subprocess.check_call(('cf', 'start', self.app_name))
+        except subprocess.CalledProcessError as e:
+            print(self.get_recent_logs())
+            raise e
 
     def setUpCF(self, package_name):
         subdomain = "ops-" + str(uuid.uuid4()).split("-")[0]

--- a/tests/usecase/test_fastdeploy.py
+++ b/tests/usecase/test_fastdeploy.py
@@ -18,7 +18,9 @@ class TestCaseFastdeploy(basetest.BaseTest):
         r = requests.post(full_uri, auth=('deploy', self.mx_password), files={
             'file': open('MontBlancApp671b.mpk', 'rb'),
         })
+
         if r.status_code != 200:
-            print r.text
+            print(self.get_recent_logs())
+            print(r.text)
         assert r.status_code == 200
         assert "STARTED" in r.text

--- a/tests/usecase/test_mono4.py
+++ b/tests/usecase/test_mono4.py
@@ -1,0 +1,16 @@
+import basetest
+import subprocess
+import requests
+import time
+
+
+class TestCaseMono4(basetest.BaseTest):
+
+    def setUp(self):
+        self.setUpCF('mono4-7-build20010.mpk')
+        subprocess.check_call(('cf', 'set-env', self.app_name, 'DEPLOY_PASSWORD', self.mx_password))
+        self.startApp()
+
+    def test_mono4(self):
+        self.assert_app_running(self.app_name)
+        self.assert_string_in_recent_logs(self.app_name, 'Selecting Mono Runtime: mono-4')


### PR DESCRIPTION
Blacklisted mendix 7 and all earlier versions require mono3 to build. Mendix 7.0.2 and later uses mono4 