### PR TITLE
Mark SERVER_ID as deprecated and use LICENSE_ID instead because this less confusing

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ License Activation
 To activate a license on your application you need license credentials. These credentials can be obtained by contacting Mendix Support.
 
 ```
-cf set-env <YOUR_APP> SERVER_ID <UUID>
+cf set-env <YOUR_APP> LICENSE_ID <UUID>
 cf set-env <YOUR_APP> LICENSE_KEY <LicenseKey>
 ```
 

--- a/start.py
+++ b/start.py
@@ -143,11 +143,11 @@ def activate_license():
     prefs_template = """<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE map SYSTEM "http://java.sun.com/dtd/preferences.dtd">
 <map MAP_XML_VERSION="1.0">
-  <entry key="id" value="{{SERVER_ID}}"/>
+  <entry key="id" value="{{LICENSE_ID}}"/>
   <entry key="license_key" value="{{LICENSE_KEY}}"/>
 </map>"""
 
-    license = os.environ.get(
+    license_key = os.environ.get(
         'FORCED_LICENSE_KEY',
         os.environ.get('LICENSE_KEY', None)
     )
@@ -155,12 +155,22 @@ def activate_license():
         'FORCED_SERVER_ID',
         os.environ.get('SERVER_ID', None)
     )
-    if license is not None and server_id is not None:
+    license_id = os.environ.get(
+        'FORCED_LICENSE_ID',
+        os.environ.get('LICENSE_ID', None)
+    )
+    if server_id:
+        logger.warning('SERVER_ID is deprecated, please use LICENSE_ID instead')
+
+    if not license_id:
+        license_id = server_id
+
+    if license_key is not None and license_id is not None:
         logger.debug('A license was supplied so going to activate it')
         prefs_body = prefs_template.replace(
-            '{{SERVER_ID}}', server_id
+            '{{LICENSE_ID}}', license_id
             ).replace(
-            '{{LICENSE_KEY}}', license
+            '{{LICENSE_KEY}}', license_key
             )
         with open(os.path.join(prefs_dir, 'prefs.xml'), 'w') as prefs_file:
             prefs_file.write(prefs_body)

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -22,5 +22,9 @@ virtualenv -p python2 venv
 . venv/bin/activate
 pip install -r requirements.txt
 
+echo "Begin clean up of environment"
+cf apps | grep ops- | awk '{print $1}' | xargs -n 1 cf delete -r -f | true
+cf s | grep ops- | awk '{print $1}' | xargs -n 1 cf ds -f | true
+echo "Completed environment clean up"
 
 python venv/bin/nosetests -vv --processes=3 --process-timeout=600 usecase/

--- a/tests/usecase/basetest.py
+++ b/tests/usecase/basetest.py
@@ -41,7 +41,7 @@ class BaseTest(unittest.TestCase):
 
         cmds = [
             "wget -c -O \"%s\" \"%s\"" % (self.package_name, self.package_url),
-            "cf push -p %s -n %s %s --no-start -k 2G -b https://github.com/mendix/cf-mendix-buildpack.git#%s" % (self.package_name, subdomain, self.app_name, self.branch_name),
+            "cf push -p %s -n %s %s --no-start -k 3G -m 2G -b https://github.com/mendix/cf-mendix-buildpack.git#%s" % (self.package_name, subdomain, self.app_name, self.branch_name),
             "cf create-service schnapps basic \"%s-schnapps\"" % self.app_name,
             "cf create-service PostgreSQL \"Basic PostgreSQL Plan\" \"%s-database\"" % self.app_name,
             "cf create-service amazon-s3 shared \"%s-storage\"" % self.app_name,

--- a/tests/usecase/test_mono4.py
+++ b/tests/usecase/test_mono4.py
@@ -7,7 +7,7 @@ import time
 class TestCaseMono4(basetest.BaseTest):
 
     def setUp(self):
-        self.setUpCF('mono4-7-build20010.mpk')
+        self.setUpCF('mono4-mx7.mpk')
         subprocess.check_call(('cf', 'set-env', self.app_name, 'DEPLOY_PASSWORD', self.mx_password))
         self.startApp()
 


### PR DESCRIPTION
Internal processes refer `SERVER_ID` being the computed value of the `UUID` as input. To avoid confusion we will call this `UUID` value `LICENSE_ID` from now on.