### PR TITLE
Introduce FORCED_ACCESS_RESTRICTIONS to override default behavior

### DIFF
--- a/lib/nginx.py
+++ b/lib/nginx.py
@@ -37,7 +37,11 @@ def get_path_config():
     }
     Default for satisfy is all
     '''
-    restrictions = json.loads(os.environ.get('ACCESS_RESTRICTIONS', '{}'))
+    forced_restrictions = os.environ.get('FORCED_ACCESS_RESTRICTIONS')
+    if forced_restrictions:
+        restrictons = json.loads(forced_restrictions)
+    else:
+        restrictions = json.loads(os.environ.get('ACCESS_RESTRICTIONS', '{}'))
     result = ''
     if '/' not in restrictions:
         restrictions['/'] = {}

--- a/start.py
+++ b/start.py
@@ -20,7 +20,7 @@ from buildpackutil import i_am_primary_instance
 
 logger.setLevel(buildpackutil.get_buildpack_loglevel())
 
-logger.info('Started Mendix Cloud Foundry Buildpack v1.2.2')
+logger.info('Started Mendix Cloud Foundry Buildpack v1.2.3')
 
 logging.getLogger('m2ee').propagate = False
 


### PR DESCRIPTION
We can use this option to temporary set access restrictions for apps via `cf set-env` because this feature is not yet complete in the deployment portal UI.

Introduces `FORCED_ACCESS_RESTRICTIONS` which has higher priority over `ACCESS_RESTRICTIONS` set by deployment portal.