### PR TITLE
fix nginx logging filling up disk

### DIFF
--- a/nginx/conf/nginx.conf
+++ b/nginx/conf/nginx.conf
@@ -1,13 +1,12 @@
 worker_processes 1;
 daemon off;
 
-error_log ROOT/nginx/logs/error.log;
+error_log stderr;
 events { worker_connections 1024; }
 
 http {
     XFRAMEOPTIONS
-    log_format cloudfoundry '$host $remote_addr - $http_referer - [$time_local] "$request" $status $body_bytes_sent $request_time';
-    access_log ROOT/nginx/logs/access.log cloudfoundry;
+    access_log /dev/null; # we use cloud foundry RTR logging
     default_type application/octet-stream;
     include mime.types;
     include proxy_params;

--- a/nginx/conf/nginx.conf
+++ b/nginx/conf/nginx.conf
@@ -6,7 +6,7 @@ events { worker_connections 1024; }
 
 http {
     XFRAMEOPTIONS
-    access_log /dev/null; # we use cloud foundry RTR logging
+    access_log off; # we use cloud foundry RTR logging
     default_type application/octet-stream;
     include mime.types;
     include proxy_params;

--- a/start.py
+++ b/start.py
@@ -20,7 +20,7 @@ from buildpackutil import i_am_primary_instance
 
 logger.setLevel(buildpackutil.get_buildpack_loglevel())
 
-logger.info('Started Mendix Cloud Foundry Buildpack v1.2.3')
+logger.info('Started Mendix Cloud Foundry Buildpack v1.2.4')
 
 logging.getLogger('m2ee').propagate = False
 
@@ -112,17 +112,10 @@ def set_up_nginx_files(m2ee):
         file_name_suffix='-mxbuild'
     )
 
-    buildpackutil.mkdir_p('nginx/logs')
-    subprocess.check_call(['touch', 'nginx/logs/access.log'])
-    subprocess.check_call(['touch', 'nginx/logs/error.log'])
-
 
 def start_nginx():
     subprocess.Popen([
         'nginx/sbin/nginx', '-p', 'nginx', '-c', 'conf/nginx.conf'
-    ])
-    subprocess.Popen([
-        'tail', '-f', 'nginx/logs/error.log'
     ])
 
 


### PR DESCRIPTION
This changes error_log to log to stderr natively, we didn't do anything
with the access log so just write that to /dev/null. Access logs are
handled by cloud foundry RTR logging already.