### PR TITLE
start.py: git fetch a specific tag / runtime version

### DIFF
--- a/start.py
+++ b/start.py
@@ -607,9 +607,10 @@ def set_up_m2ee_client(vcap_data):
                                    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         process.communicate()
         if process.returncode != 0:
-            # do a 'git fetch --tags' to refresh the bare repo, then retry to checkout the runtime version
+            # 'git fetch' the version we want to the bare repo, then retry to checkout the runtime version
             logger.info('mendix runtime version {mx_version} is missing in this rootfs'.format(mx_version=version))
-            process = subprocess.Popen(['git', 'fetch', '--tags', '&&', 'git', 'checkout', str(version), '-f'],
+            process = subprocess.Popen(['git', 'fetch', 'origin', 'refs/tags/{0}:refs/tags/{0}'.format(str(version)),
+                                        '&&', 'git', 'checkout', str(version), '-f'],
                                        cwd=mendix_runtimes_path, env=env, stdout=subprocess.PIPE,
                                        stderr=subprocess.PIPE)
             process.communicate()


### PR DESCRIPTION
By fetching a specific tag we only transfer the minimal necessary amount of
data to get the runtime/mxbuild version we want. Also, when the version we want
is not present it already fails when fetching, which makes it fallback faster.

Changing this makes it also compatible with a local shallow repository (git
fetch --tags, wouldn't fetch anything in that case).