### PR TITLE
Write errors returned by MxBuild to STDERR

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -270,6 +270,7 @@ def buildstatus_callback(error_file):
             builddata = b.read()
     else:
         builddata = json.dumps(generic_build_failure)
+    logging.error('MxBuild returned errors: %s' % builddata)
     callback_url = os.environ.get('BUILD_STATUS_CALLBACK_URL')
     if callback_url:
         logging.info('Submitting build status')


### PR DESCRIPTION
Always write errors returned by MxBuild to STDERR; better safe than sorry.

Don't forget to bump version number afterwards.