### PR TITLE
Revert absolute requests metrics

### DIFF
--- a/lib/metrics.py
+++ b/lib/metrics.py
@@ -25,7 +25,6 @@ class MetricsEmitterThread(threading.Thread):
         logger.debug(
             'Starting metrics emitter with interval %d' % self.interval
         )
-        previous_requests_stats = {}
         while True:
 
             stats = {
@@ -36,25 +35,6 @@ class MetricsEmitterThread(threading.Thread):
             if buildpackutil.i_am_primary_instance():
                 stats = self._inject_storage_stats(stats)
                 stats = self._inject_database_stats(stats)
-
-            try:
-                new_request_stats = stats['mendix_runtime']['requests']
-                diff_request_stats = {}
-
-                for key, new in new_request_stats.iteritems():
-                    if key in previous_requests_stats:
-                        prev = previous_requests_stats[key]
-                        delta = max(0, (new - prev) / float(self.interval))
-                        diff_request_stats[key] = delta
-                    else:
-                        # can't calculate req/sec
-                        pass
-
-                stats['mendix_runtime']['requests'] = diff_request_stats
-                previous_requests_stats = new_request_stats
-
-            except KeyError:
-                pass
 
             logger.info('MENDIX-METRICS: ' + json.dumps(stats))
 

--- a/start.py
+++ b/start.py
@@ -21,7 +21,7 @@ from buildpackutil import i_am_primary_instance
 
 logger.setLevel(buildpackutil.get_buildpack_loglevel())
 
-logger.info('Started Mendix Cloud Foundry Buildpack v1.4.4')
+logger.info('Started Mendix Cloud Foundry Buildpack v1.4.5')
 
 logging.getLogger('m2ee').propagate = False
 


### PR DESCRIPTION
We are reverting this because trends api is responsible for emitting the values correctly.