### PR TITLE
Preserve the protocol by using 200 instead of error status

### DIFF
--- a/lib/instadeploy.py
+++ b/lib/instadeploy.py
@@ -109,7 +109,7 @@ class MPKUploadHandler(BaseHTTPRequestHandler):
 
         except MxBuildFailure as mbf:
             logger.warning('InstaDeploy terminating with MxBuildFailure: {}'.format(mbf.message))
-            return self._terminate(mbf.status_code, {}, mbf.mxbuild_response)
+            return self._terminate(200, {'state': 'FAILED'}, mbf.mxbuild_response)
 
         except Exception:
             return self._terminate(500, {


### PR DESCRIPTION
The user of the API receives 200 based on the previous implementation
but with more details in the response body. We change the `state` to
`FAILED` to remain consistent.