### PR TITLE
If starting app fails, record it at S3

### DIFF
--- a/start.py
+++ b/start.py
@@ -965,9 +965,10 @@ if __name__ == '__main__':
         start_metrics(m2ee)
         start_nginx()
         loop_until_process_dies(m2ee)
-    except Exception:
+    except Exception as e:
         x = traceback.format_exc()
         logger.error('Starting app container failed: %s' % x)
         callback_url = os.environ.get('BUILD_STATUS_CALLBACK_URL')
         if callback_url:
             requests.put(callback_url, x)
+        raise e

--- a/start.py
+++ b/start.py
@@ -965,10 +965,10 @@ if __name__ == '__main__':
         start_metrics(m2ee)
         start_nginx()
         loop_until_process_dies(m2ee)
-    except Exception as e:
+    except Exception:
         x = traceback.format_exc()
         logger.error('Starting app container failed: %s' % x)
         callback_url = os.environ.get('BUILD_STATUS_CALLBACK_URL')
         if callback_url:
             requests.put(callback_url, x)
-        raise e
+        raise

--- a/start.py
+++ b/start.py
@@ -18,10 +18,11 @@ import instadeploy
 import metrics
 from nginx import get_path_config, gen_htpasswd
 from buildpackutil import i_am_primary_instance
+import traceback
 
 logger.setLevel(buildpackutil.get_buildpack_loglevel())
 
-logger.info('Started Mendix Cloud Foundry Buildpack v1.4.10')
+logger.info('Started Mendix Cloud Foundry Buildpack v1.4.11')
 
 logging.getLogger('m2ee').propagate = False
 
@@ -956,10 +957,17 @@ if __name__ == '__main__':
 
     signal.signal(signal.SIGTERM, sigterm_handler)
 
-    service_backups()
-    set_up_nginx_files(m2ee)
-    complete_start_procedure_safe_to_use_for_restart(m2ee)
-    set_up_instadeploy_if_deploy_password_is_set(m2ee)
-    start_metrics(m2ee)
-    start_nginx()
-    loop_until_process_dies(m2ee)
+    try:
+        service_backups()
+        set_up_nginx_files(m2ee)
+        complete_start_procedure_safe_to_use_for_restart(m2ee)
+        set_up_instadeploy_if_deploy_password_is_set(m2ee)
+        start_metrics(m2ee)
+        start_nginx()
+        loop_until_process_dies(m2ee)
+    except Exception:
+        x = traceback.format_exc()
+        logger.error('Starting app container failed: %s' % x)
+        callback_url = os.environ.get('BUILD_STATUS_CALLBACK_URL')
+        if callback_url:
+            requests.put(callback_url, x)

--- a/start.py
+++ b/start.py
@@ -22,7 +22,7 @@ import traceback
 
 logger.setLevel(buildpackutil.get_buildpack_loglevel())
 
-logger.info('Started Mendix Cloud Foundry Buildpack v1.4.11')
+logger.info('Started Mendix Cloud Foundry Buildpack v1.4.14')
 
 logging.getLogger('m2ee').propagate = False
 


### PR DESCRIPTION
Use the same approach as when MxBuild fails to build the package and
write the failure result into S3. This will ensure that Deployer always
gets a correct state from S3 whenever there's a failure either in
`compile` phase or `start` phase.