### PR TITLE
Support SAP S3 objectstore service instance

### DIFF
--- a/start.py
+++ b/start.py
@@ -282,7 +282,7 @@ def _get_s3_specific_config(vcap_services, m2ee):
     amazon_s3 = None
 
     for key in vcap_services:
-        if key.startswith("amazon-s3"):
+        if key.startswith("amazon-s3") or key == "objectstore":
             amazon_s3 = key
 
     if amazon_s3:
@@ -294,6 +294,8 @@ def _get_s3_specific_config(vcap_services, m2ee):
             encryption_keys = _conf['encryption_keys']
         if 'key_suffix' in _conf:
             key_suffix = _conf['key_suffix']
+        if 'host' in _conf:
+            endpoint = _conf['host']
         if 'endpoint' in _conf:
             endpoint = _conf['endpoint']
 

--- a/start.py
+++ b/start.py
@@ -21,7 +21,7 @@ from buildpackutil import i_am_primary_instance
 
 logger.setLevel(buildpackutil.get_buildpack_loglevel())
 
-logger.info('Started Mendix Cloud Foundry Buildpack v1.4.11')
+logger.info('Started Mendix Cloud Foundry Buildpack v1.4.12')
 
 logging.getLogger('m2ee').propagate = False
 


### PR DESCRIPTION
Requested by Erno:

Would it be possible to add the support for SAP S3 object storage within our buildpack?
 
See below the details and the VCAP settings.
 
https://help.sap.com/doc/49fbb9cb6bda4b7ca241da19197c6ad3/Cloud/en-US/objectstore.pdf

Sample `VCAP_SERVICES`
```json
System-Provided:
{
 "VCAP_SERVICES": {
 "objectstore": [
 {
 "credentials": {
 "access_key_id": "<some_access_key_id>",
 "bucket": "<some_bucket_name>",
 "host": "<region_specific_s3_endpoint>",
 "secret_access_key": "<some_secret_access_key>",
 "uri": "s3://
<some_access_key_id>:<some_secret_access_key>@<region_specific_s3_endpoint>/
<some_bucket_name>",
 "username": "<some_username>"
 },
 "label": "objectstore",
 "name": "<serviceInstanceName>",
 "plan": "s3-standard",
 "provider": null,
 "syslog_drain_url": null,
 "tags": [
 "blobStore",
 "objectStore"
 ],
 "volume_mounts": []
 }
 ]
 } 
```
