### PR TITLE
Support dashdb in bluemix

### DIFF
--- a/lib/buildpackutil.py
+++ b/lib/buildpackutil.py
@@ -99,6 +99,8 @@ def get_database_uri_from_vcap():
     for key in vcap_services:
         if key.startswith("rds"):
             return vcap_services[key][0]['credentials']['uri']
+        if key.startswith("dashDB"):
+            return vcap_services[key][0]['credentials']['uri']
 
     return None
 

--- a/start.py
+++ b/start.py
@@ -23,7 +23,7 @@ import traceback
 logger.setLevel(buildpackutil.get_buildpack_loglevel())
 
 
-logger.info('Started Mendix Cloud Foundry Buildpack v1.4.17')
+logger.info('Started Mendix Cloud Foundry Buildpack v1.4.18')
 
 logging.getLogger('m2ee').propagate = False
 


### PR DESCRIPTION
Services is exposed as:

```json
  "dashDB For Transactions": [
   {
    "credentials": {
     "db": "BLUDB",
    ...
     "uri": "db2://bluadmin:XXXXX@dashdb-XXXX-small-yp-XXXX-01.serv
ices.dal.bluemix.net:50000/BLUDB",
     "username": "bluadmin"
    },
    "label": "dashDB For Transactions",
    "name": "dashDB for Transactions SQL Database-mg",
    "plan": "EnterpriseForTransactions2.8.500",
    "provider": null,
    "syslog_drain_url": null,
    "tags": [
     "big_data",
     "ibm_created",
     "db2",
     "sqldb",
     "purescale",
     "sql",
     "ibm_dedicated_public",
     "db2 on cloud",
     "db2oncloud",
     "dash",
     "dashdb",
     "oracle",
     "database",
     "transactions",
     "flex",
     "dbaas"
    ],
    "volume_mounts": []
   }
  ]
```