### PR TITLE
Get MySQL 2.0 uri from VCAP

### DIFF
--- a/lib/buildpackutil.py
+++ b/lib/buildpackutil.py
@@ -83,6 +83,7 @@ def get_database_uri_from_vcap():
 
     for service_type_name in (
         'p-mysql',
+        'p.mysql',
         'elephantsql',
         'cleardb',
         'PostgreSQL',


### PR DESCRIPTION
For MySQL 2.0 VCAP service name changed from p-mysql to p.msql.
See: http://docs.pivotal.io/p-mysql/2-0/index.html#AboutTile