### PR TITLE
Add logic to terminate child processes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: sh
 
 before_script:
-  - wget --quiet "https://cli.run.pivotal.io/stable?release=debian64&version=6.28.0&source=github-rel" -O cli.deb
+  - wget --quiet "https://cli.run.pivotal.io/stable?release=debian64&version=6.30.0&source=github-rel" -O cli.deb
   - sudo dpkg -i cli.deb
   - sudo curl https://download.mendix.com/Mendix-CA-G2.crt -o /usr/local/share/ca-certificates/ca.crt
   - sudo update-ca-certificates

--- a/tests/usecase/basetest.py
+++ b/tests/usecase/basetest.py
@@ -28,21 +28,27 @@ class BaseTest(unittest.TestCase):
         self.subdomain = "ops-" + self.app_id
         self.app_name = "%s.%s" % (self.subdomain, self.cf_domain)
 
-    def startApp(self):
+    def startApp(self, expect_failure=False):
         try:
             self.cmd(('cf', 'start', self.app_name))
         except subprocess.CalledProcessError as e:
-            print(self.get_recent_logs())
-            raise e
+            if expect_failure:
+                return
+            else:
+                print(e.output)
+                print(self.get_recent_logs())
+                raise e
+        if expect_failure:
+            raise Exception('App unexpectedly started successfully')
 
-    def setUpCF(self, package_name, env_vars=None):
+    def setUpCF(self, package_name, health_timeout=180, env_vars=None):
         try:
-            self._setUpCF(package_name, env_vars=env_vars)
+            self._setUpCF(package_name, health_timeout, env_vars=env_vars)
         except:
             self.tearDown()
             raise
 
-    def _setUpCF(self, package_name, env_vars=None):
+    def _setUpCF(self, package_name, health_timeout, env_vars=None):
         self.package_name = package_name
         self.package_url = os.environ.get(
             "PACKAGE_URL",
@@ -63,6 +69,7 @@ class BaseTest(unittest.TestCase):
                 '--no-start',
                 '-k', '3G',
                 '-m', '2G',
+                '-t', str(health_timeout),
                 '-b', (
                     'https://github.com/mendix/cf-mendix-buildpack.git#%s'
                     % self.branch_name
@@ -125,8 +132,7 @@ class BaseTest(unittest.TestCase):
             pass
 
     def cmd(self, command):
-        subprocess.check_call(
+        return subprocess.check_output(
             command,
-            stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )

--- a/tests/usecase/basetest.py
+++ b/tests/usecase/basetest.py
@@ -28,9 +28,12 @@ class BaseTest(unittest.TestCase):
         self.subdomain = "ops-" + self.app_id
         self.app_name = "%s.%s" % (self.subdomain, self.cf_domain)
 
-    def startApp(self, expect_failure=False):
+    def startApp(self, start_timeout=None, expect_failure=False):
         try:
-            self.cmd(('cf', 'start', self.app_name))
+            env = {}
+            if start_timeout:
+                env['CF_STARTUP_TIMEOUT'] = str(start_timeout)
+            self.cmd(('cf', 'start', self.app_name), env=env)
         except subprocess.CalledProcessError as e:
             if expect_failure:
                 return
@@ -131,8 +134,12 @@ class BaseTest(unittest.TestCase):
         else:
             pass
 
-    def cmd(self, command):
+    def cmd(self, command, env=None):
+        effective_env = os.environ.copy()
+        if env:
+            effective_env.update(env)
         return subprocess.check_output(
             command,
             stderr=subprocess.PIPE,
+            env=effective_env,
         )

--- a/tests/usecase/basetest.py
+++ b/tests/usecase/basetest.py
@@ -98,8 +98,8 @@ class BaseTest(unittest.TestCase):
     def tearDown(self):
         self.cmd(('./delete-app.sh', self.app_name))
 
-    def assert_app_running(self, app_name, path="/xas/", code=401):
-        full_uri = "https://" + app_name + path
+    def assert_app_running(self, path="/xas/", code=401):
+        full_uri = "https://" + self.app_name + path
         r = requests.get(full_uri)
         assert r.status_code == code
 
@@ -108,8 +108,8 @@ class BaseTest(unittest.TestCase):
             'cf', 'logs', self.app_name, '--recent',
         )), 'utf-8')
 
-    def assert_string_in_recent_logs(self, app_name, substring):
-        output = subprocess.check_output(('cf', 'logs', app_name, '--recent'))
+    def assert_string_in_recent_logs(self, substring):
+        output = self.get_recent_logs()
         if output.find(substring) > 0:
             pass
         else:

--- a/tests/usecase/basetest.py
+++ b/tests/usecase/basetest.py
@@ -116,6 +116,14 @@ class BaseTest(unittest.TestCase):
             print(output)
             self.fail('Failed to find substring in recent logs: ' + substring)
 
+    def assert_string_not_in_recent_logs(self, substring):
+        output = self.get_recent_logs()
+        if output.find(substring) > 0:
+            print(output)
+            self.fail('Found substring in recent logs: ' + substring)
+        else:
+            pass
+
     def cmd(self, command):
         subprocess.check_call(
             command,

--- a/tests/usecase/test_buildstatus_callback.py
+++ b/tests/usecase/test_buildstatus_callback.py
@@ -16,7 +16,7 @@ class TestCaseBuildStatusCallback(basetest.BaseTest):
     def test_model_has_no_inconsistency_errors(self):
         self._test_helper('empty-model-7.0.2.mpk')
         self.startApp()
-        self.assert_app_running(self.app_name)
+        self.assert_app_running()
 
     def _test_helper(self, package_name):
         self.setUpCF(package_name, env_vars={

--- a/tests/usecase/test_check_java_crash_restarts_process.py
+++ b/tests/usecase/test_check_java_crash_restarts_process.py
@@ -13,7 +13,7 @@ class TestCaseJavaCrashRestartsProcess(basetest.BaseTest):
         self.startApp()
 
     def test_check_java_crash_restarts_process(self):
-        self.assert_app_running(self.app_name)
+        self.assert_app_running()
         print('killing java to see if app will actually restart')
         self.cmd((
             'cf', 'ssh', self.app_name, '-c', 'killall java'

--- a/tests/usecase/test_check_mda_app_deployed.py
+++ b/tests/usecase/test_check_mda_app_deployed.py
@@ -8,4 +8,4 @@ class TestCaseMdaAppDeployed(basetest.BaseTest):
         self.startApp()
 
     def test_mda_app_deployed_unauthorized(self):
-        self.assert_app_running(self.app_name)
+        self.assert_app_running()

--- a/tests/usecase/test_check_mpk_app_deployed.py
+++ b/tests/usecase/test_check_mpk_app_deployed.py
@@ -8,4 +8,4 @@ class TestCaseMpkAppDeployed(basetest.BaseTest):
         self.startApp()
 
     def test_mpk_app_deployed_unauthorized(self):
-        self.assert_app_running(self.app_name)
+        self.assert_app_running()

--- a/tests/usecase/test_check_terminate_process_on_crashing_app.py
+++ b/tests/usecase/test_check_terminate_process_on_crashing_app.py
@@ -1,0 +1,19 @@
+import basetest
+
+
+class TestCaseTerminateChildProcessesCompleteOnCrashingApp(basetest.BaseTest):
+
+    def setUp(self):
+        self.setUpCF(
+            'Sample-StartError.mpk',
+            health_timeout=60,
+            env_vars={
+                'DEPLOY_PASSWORD': self.mx_password,
+                'METRICS_INTERVAL': '10',
+            }
+        )
+
+    def test_verify_termination_logs(self):
+        self.startApp(expect_failure=True)
+        self.assert_string_in_recent_logs('start failed, stopping')
+        self.assert_string_not_in_recent_logs('health check never passed')

--- a/tests/usecase/test_constants.py
+++ b/tests/usecase/test_constants.py
@@ -19,6 +19,5 @@ class TestCaseConstants(basetest.BaseTest):
     def test_constant_is_set(self):
         # this is enough because google.com would *always* respond
         self.assert_string_in_recent_logs(
-            self.app_name,
             'java.net.ConnectException: Connection refused'
         )

--- a/tests/usecase/test_custom_runtime_settings.py
+++ b/tests/usecase/test_custom_runtime_settings.py
@@ -5,16 +5,17 @@ import json
 class TestCaseCustomRuntimeSettings(basetest.BaseTest):
 
     def setUp(self):
-        self.setUpCF('sample-6.2.0.mda', env_vars={
-            'MXRUNTIME_PersistentSessions': 'True',
-            'CUSTOM_RUNTIME_SETTINGS': json.dumps({
-                'SourceDatabaseType': 'MySQL'
-            }),
-        })
-        try:
-            self.startApp()
-        except:
-            pass  # expected, this will fail due to MySQL
+        self.setUpCF(
+            'sample-6.2.0.mda',
+            health_timeout=60,
+            env_vars={
+                'MXRUNTIME_PersistentSessions': 'True',
+                'CUSTOM_RUNTIME_SETTINGS': json.dumps({
+                    'SourceDatabaseType': 'MySQL'
+                }),
+            },
+        )
+        self.startApp(expect_failure=True)
 
     def test_custom_runtime_setting_is_set(self):
         self.assert_string_in_recent_logs(

--- a/tests/usecase/test_custom_runtime_settings.py
+++ b/tests/usecase/test_custom_runtime_settings.py
@@ -18,6 +18,5 @@ class TestCaseCustomRuntimeSettings(basetest.BaseTest):
 
     def test_custom_runtime_setting_is_set(self):
         self.assert_string_in_recent_logs(
-            self.app_name,
             'MySQL'
         )

--- a/tests/usecase/test_emit_metrics.py
+++ b/tests/usecase/test_emit_metrics.py
@@ -12,7 +12,7 @@ class TestCaseEmitMetrics(basetest.BaseTest):
 
     def test_read_metrics_in_logs(self):
         time.sleep(10)
-        self.assert_string_in_recent_logs(self.app_name, 'MENDIX-METRICS: ')
-        self.assert_string_in_recent_logs(self.app_name, 'storage')
-        self.assert_string_in_recent_logs(self.app_name, 'number_of_files')
-        self.assert_string_in_recent_logs(self.app_name, 'critical_logs_count')
+        self.assert_string_in_recent_logs('MENDIX-METRICS: ')
+        self.assert_string_in_recent_logs('storage')
+        self.assert_string_in_recent_logs('number_of_files')
+        self.assert_string_in_recent_logs('critical_logs_count')

--- a/tests/usecase/test_logging.py
+++ b/tests/usecase/test_logging.py
@@ -11,5 +11,5 @@ class TestCaseLogging(basetest.BaseTest):
         self.startApp()
 
     def test_logging_config(self):
-        self.assert_app_running(self.app_name)
-        self.assert_string_in_recent_logs(self.app_name, 'TRACE - Jetty')
+        self.assert_app_running()
+        self.assert_string_in_recent_logs('TRACE - Jetty')

--- a/tests/usecase/test_mono4.py
+++ b/tests/usecase/test_mono4.py
@@ -10,5 +10,5 @@ class TestCaseMono4(basetest.BaseTest):
         self.startApp()
 
     def test_mono4(self):
-        self.assert_app_running(self.app_name)
-        self.assert_string_in_recent_logs(self.app_name, 'Selecting Mono Runtime: mono-4')
+        self.assert_app_running()
+        self.assert_string_in_recent_logs('Selecting Mono Runtime: mono-4')


### PR DESCRIPTION
On sys exit:

- Stop M2EE
- For every child process, try to terminate
- Allow each child to terminate gracefully for 1 second
- Wait maximum 3 seconds for all child processes
- Send SIGKILL in the end.

Signed-off-by: @emirozer