### PR TITLE
nginx config: use relative redirect

### DIFF
--- a/nginx/conf/nginx.conf
+++ b/nginx/conf/nginx.conf
@@ -24,7 +24,7 @@ http {
 
     tcp_nopush on;
     keepalive_timeout 30;
-    port_in_redirect off;
+    absolute_redirect off;
     server_tokens off;
 
     upstream mendix {

--- a/start.py
+++ b/start.py
@@ -25,7 +25,7 @@ from buildpackutil import i_am_primary_instance
 logger.setLevel(buildpackutil.get_buildpack_loglevel())
 
 
-logger.info('Started Mendix Cloud Foundry Buildpack v1.6.1')
+logger.info('Started Mendix Cloud Foundry Buildpack v1.6.2')
 
 logging.getLogger('m2ee').propagate = False
 


### PR DESCRIPTION
Before this, a request to https://DOMAIN/xas resulted in a redirect to
http://DOMAIN/xas/.