### PR TITLE
metrics: rm user_sessions content from MENDIX-METRICS

### DIFF
--- a/lib/metrics.py
+++ b/lib/metrics.py
@@ -46,7 +46,8 @@ class MetricsEmitterThread(threading.Thread):
                 self.m2ee.client,
                 self.m2ee.config
             )
-            m2ee_stats['sessions']['user_sessions'] = {}
+            if 'sessions' in m2ee_stats:
+                m2ee_stats['sessions']['user_sessions'] = {}
             m2ee_stats = munin.augment_and_fix_stats(
                 m2ee_stats,
                 self.m2ee.runner.get_pid(),

--- a/lib/metrics.py
+++ b/lib/metrics.py
@@ -46,6 +46,7 @@ class MetricsEmitterThread(threading.Thread):
                 self.m2ee.client,
                 self.m2ee.config
             )
+            m2ee_stats['sessions']['user_sessions'] = {}
             m2ee_stats = munin.augment_and_fix_stats(
                 m2ee_stats,
                 self.m2ee.runner.get_pid(),


### PR DESCRIPTION
The user_sessions provided by the Mendix runtime contains a json map of
guids and per guid a list of user-agents. For example:

> "user_sessions": {"562949953461327": ["Mozilla/5.0 (Windows NT 6.1;
> WOW64; Trident/7.0; rv:11.0) like Gecko"], "562949953462057":
> ["Mozilla/5.0...

When having many user sessions, logging this information could make
loglines longer than 64K characters. CF will wrap these lines, resulting
in invalid JSON.

Logs even get lost completely when logging just under 64K characters:
https://www.pivotaltracker.com/n/projects/993188/stories/101894886

We do not use this information for metrics. We are only interested in
the numbers (named_users, anonymous_sessions, named_user_sessions).
So remove the user_sessions content.

Re: [CLD-1366]