### PR TITLE
Adds postgresql_shared as database type

### DIFF
--- a/lib/buildpackutil.py
+++ b/lib/buildpackutil.py
@@ -91,6 +91,7 @@ def get_database_uri_from_vcap():
         'mariadb',
         'postgresql',
         'rds',
+        'postgresql_shared',
     ):
         if vcap_services and service_type_name in vcap_services:
             return vcap_services[service_type_name][0]['credentials']['uri']


### PR DESCRIPTION
As requested by @ernororive today:
This is to support a ‘postgres service broker’ which allows developers to divide a big postgres instance into smaller databases used by different apps.

Version should probably become v1.7.1. Bump and tag after merging.