### PR TITLE
don't use http proxy for m2ee client

### DIFF
--- a/lib/m2ee/client.py
+++ b/lib/m2ee/client.py
@@ -44,7 +44,7 @@ class M2EEClient:
         if params:
             body["params"] = params
         body = json.dumps(body)
-        h = httplib2.Http(timeout=timeout)  # httplib does not like os.fork
+        h = httplib2.Http(timeout=timeout, proxy_info=None)  # httplib does not like os.fork
         logger.trace("M2EE request body: %s" % body)
         (response_headers, response_body) = h.request(self._url, "POST", body,
                                                       headers=self._headers)


### PR DESCRIPTION
When http_proxy/https_proxy environment variables are used, fetching
external urls will be handled via the proxy automatically via
requests/urllib. However, for communicating with the m2ee api in the
runtime, we don't want to use the proxy server as it's all within
the same container.