### PR TITLE
fix mxbuild full deploy response formatting

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -240,10 +240,11 @@ def buildstatus_callback(error_file):
             "locations": []
         }
     ]}
-    if os.path.exists(error_file):
+    try:
         with open(error_file, 'r') as b:
-            builddata = b.read()
-    else:
+            builddata = json.dumps(json.load(b))
+    except (IOError, ValueError):
+        logging.exception('Could not read mxbuild error file')
         builddata = json.dumps(generic_build_failure)
     logging.error('MxBuild returned errors: %s' % builddata)
     callback_url = os.environ.get('BUILD_STATUS_CALLBACK_URL')


### PR DESCRIPTION
For intadeploy we parse and do json.dumps on the mxbuild response too,
we should do the same for full deploy. Actually, we should probably
change the formatting froms string to actual json, but refactoring that
is a lot of effort for the consumers.