### PR TITLE
increase the amount of worker_connections for nginx

### DIFF
--- a/nginx/conf/nginx.conf
+++ b/nginx/conf/nginx.conf
@@ -2,7 +2,7 @@ worker_processes 1;
 daemon off;
 
 error_log stderr;
-events { worker_connections 1024; }
+events { worker_connections 4096; }
 
 http {
     XFRAMEOPTIONS

--- a/start.py
+++ b/start.py
@@ -25,7 +25,7 @@ from buildpackutil import i_am_primary_instance
 logger.setLevel(buildpackutil.get_buildpack_loglevel())
 
 
-logger.info('Started Mendix Cloud Foundry Buildpack v1.8.1')
+logger.info('Started Mendix Cloud Foundry Buildpack v1.8.2')
 
 logging.getLogger('m2ee').propagate = False
 


### PR DESCRIPTION
Applications under heavy load can get 502 responses and a notice in the
logs about "1024 worker_connections are not enough".

We should probably make this dynamic, but for now upping the limit won't
hurt.