### PR TITLE
set MALLOC_ARENA_MAX to a lower dynamic value to prevent OOM

### DIFF
--- a/start.py
+++ b/start.py
@@ -280,7 +280,7 @@ def set_jvm_memory(m2ee_section, vcap, java_version):
 
     if java_version.startswith('7'):
         javaopts.append('-XX:MaxPermSize=256M')
-    elif java_version.startswith('8'):
+    else:
         javaopts.append('-XX:MaxMetaspaceSize=256M')
 
     logger.debug('Java heap size set to %s' % heap_size)


### PR DESCRIPTION
The default behavior is 8x the number of detected CPUs . As Cloud
Foundry typically uses large host machines with smaller containers,
and the Java process is unaware of the difference in allocated CPUs,
the numbers are way off. This often leads to high native memory usage,
followed by a cgroup OOM killer event.

We go with Heroku's recommendation of lowering to a
setting of 2 for small instances. We also grown the setting linearly
with memory to be more in line with the default setting in Mendix
Cloud v3.

References:
- https://github.com/cloudfoundry/java-buildpack/issues/163
- https://devcenter.heroku.com/articles/testing-cedar-14-memory-use
- https://github.com/cloudfoundry/java-buildpack/issues/320