### PR TITLE
fix access restrictions for /_mxbuild/ and /_mxadmin/

### DIFF
--- a/nginx/conf/nginx.conf
+++ b/nginx/conf/nginx.conf
@@ -59,6 +59,7 @@ CONFIG
             auth_basic "Restricted";
             auth_basic_user_file ROOT/nginx/.htpasswd;
             proxy_pass http://mendix_admin/;
+            satisfy any;
         }
 
         location /_mxbuild/ {
@@ -66,6 +67,7 @@ CONFIG
             auth_basic_user_file ROOT/nginx/.htpasswd-mxbuild;
             MXBUILD_UPSTREAM;
             error_page 502 503 504 =503 @503-for-post;
+            satisfy any;
         }
 
         location /client-cert-check-internal {


### PR DESCRIPTION
These locations are protected by basic auth only.

Not yet tested.