### PR TITLE
Set DatabaseUseSsl to true if sslmode value is set.

### DIFF
--- a/lib/buildpackutil.py
+++ b/lib/buildpackutil.py
@@ -4,6 +4,7 @@ import json
 import errno
 import subprocess
 import logging
+import urlparse
 import sys
 sys.path.insert(0, 'lib')
 import requests
@@ -53,6 +54,15 @@ def get_database_config(development_mode=False):
         'DatabaseHost': match.group('host'),
         'DatabaseName': match.group('dbname'),
     }
+
+    if 'extra' in match.groupdict() and match.group('extra'):
+        extra = match.group('extra').lstrip('?')
+        jdbc_params = urlparse.parse_qs(extra)
+        if 'sslmode' in jdbc_params:
+            sslmode = jdbc_params['sslmode']
+            if sslmode and sslmode[0] == 'require':
+                config.update({'DatabaseUseSsl': True})
+
     if development_mode:
         config.update({
             'ConnectionPoolingMaxIdle': 1,


### PR DESCRIPTION
Official jdbc documentation:
sslmode = String
possible values include "disable", "require", "verify-ca" and
"verify-full", "allow" and "prefer" will throw an exception.
"require" will default to a non validating SSL factory and not
check the validity of the certificates. "verify-ca" and
"verify-full" use a validating SSL factory and will check that
the ca is correct and the host is correct.

Because we do not pass the original jdbc url we have to decompose the
url query params from `extra`. Also we need to map the possible sslmode
values into deciding to set `DatabaseUseSsl` to `True` or not.

source: https://jdbc.postgresql.org/documentation/head/connect.html