### PR TITLE
increase jetty.max_form_content_size to 10485760

### DIFF
--- a/m2ee.yaml
+++ b/m2ee.yaml
@@ -24,6 +24,9 @@ m2ee:
     "-XX:OnOutOfMemoryError=kill -s USR2 PYTHONPID",
  ]
 
+ jetty:
+   max_form_content_size: 10485760
+
  allow_destroy_db: true
 
  database_dump_path: 'BUILD_PATH/database'


### PR DESCRIPTION
The default maximum size Jetty permits is 200000 bytes.

We were requested to increase this to 10MB instead, as per @jtwaleson.

RE: `CLDOPS-1197`