### PR TITLE
fix logs stopping after 1GiB

### DIFF
--- a/m2ee.yaml
+++ b/m2ee.yaml
@@ -40,8 +40,8 @@ logging:
    name: FileSubscriber
    autosubscribe: INFO
    filename: BUILD_PATH/log/out.log
-   max_size: 1048576000
-   max_rotation: 10
+   max_size: 1125899906842624  # 1PiB should be enough until we implement stdout logging
+   max_rotation: 1
 
 mxruntime:
  ApplicationRootUrl: https://APP_URI/


### PR DESCRIPTION
Currently, logs stop working after 1GiB because the runtime will rotate
the file and the fifo will break. Since we're logging to a fifo instead
of a regular file, we can just bump to a much higher value and not see
this problem again.