### PR TITLE
Introduce datadog (in alpha)

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -15,6 +15,7 @@ BUILD_ERRORS_JSON = '/tmp/builderrors.json'
 
 sys.path.insert(0, os.path.join(BUILDPACK_DIR, 'lib'))
 import requests
+import datadog
 import buildpackutil
 from m2ee.version import MXVersion
 
@@ -286,6 +287,7 @@ if __name__ == '__main__':
     set_up_directory_structure()
     set_up_java()
     set_up_appdynamics()
+    datadog.compile(DOT_LOCAL_LOCATION, CACHE_DIR)
     download_mendix_version()
     copy_buildpack_resources()
     set_up_nginx()

--- a/lib/buildpackutil.py
+++ b/lib/buildpackutil.py
@@ -88,6 +88,16 @@ def get_vcap_services_data():
         return {}
 
 
+def get_vcap_data():
+    if os.environ.get('VCAP_APPLICATION'):
+        return json.loads(os.environ.get('VCAP_APPLICATION'))
+    else:
+        return {
+            'application_uris': ['example.com'],
+            'application_name': 'My App',
+        }
+
+
 def get_database_uri_from_vcap():
     vcap_services = get_vcap_services_data()
 

--- a/lib/datadog.py
+++ b/lib/datadog.py
@@ -62,7 +62,7 @@ def update_config(m2ee, app_name):
                 'run_path': '.local/datadog/run',
             },
         }
-        fh.write(yaml.dump(config))
+        fh.write(yaml.safe_dump(config))
     subprocess.check_call(('mkdir', '-p', '.local/datadog/conf.d/mendix.d'))
     subprocess.check_call(('mkdir', '-p', '.local/datadog/run'))
     with open('.local/datadog/conf.d/mendix.d/conf.yaml', 'w') as fh:
@@ -75,7 +75,7 @@ def update_config(m2ee, app_name):
                 'tags': tags,
             }],
         }
-        fh.write(yaml.dump(config))
+        fh.write(yaml.safe_dump(config))
     subprocess.check_call(('mkdir', '-p', '.local/datadog/conf.d/jmx.d'))
     with open('.local/datadog/conf.d/jmx.d/conf.yaml', 'w') as fh:
         config = {
@@ -89,7 +89,7 @@ def update_config(m2ee, app_name):
                 'java_bin_path': '.local/bin/java',
             }],
         }
-        fh.write(yaml.dump(config))
+        fh.write(yaml.safe_dump(config))
 
 
 def compile(install_path, cache_dir):

--- a/lib/datadog.py
+++ b/lib/datadog.py
@@ -1,4 +1,5 @@
 import os
+import json
 import yaml
 import subprocess
 import buildpackutil
@@ -16,6 +17,7 @@ def _get_hostname():
 def update_config(m2ee, app_name):
     if not is_enabled():
         return
+    tags = json.loads(os.getenv('DD_TAGS', '[]'))
     m2ee.config._conf['m2ee']['javaopts'].extend([
         '-Dcom.sun.management.jmxremote',
         '-Dcom.sun.management.jmxremote.port=7845',
@@ -45,8 +47,9 @@ def update_config(m2ee, app_name):
             'api_key': None,  # set via DD_API_KEY instead
             'confd_path': '.local/datadog/conf.d',
             'logs_enabled': True,
-            'log_file': '/dev/null',
+            'log_file': '/dev/null',  # will be printed via stdout/stderr
             'hostname': _get_hostname(),
+            'tags': tags,
             'process_config': {
                 'enabled': 'true',  # has to be string
                 'log_file': '/dev/null',
@@ -69,8 +72,7 @@ def update_config(m2ee, app_name):
                 'path': 'log/datadog.log',
                 'service': _get_hostname(),
                 'source': 'mendix',
-                'sourcecategory': 'sourcecode',
-                'tags': 'env:prod',
+                'tags': tags,
             }],
         }
         fh.write(yaml.dump(config))

--- a/lib/datadog.py
+++ b/lib/datadog.py
@@ -1,0 +1,111 @@
+import os
+import yaml
+import subprocess
+import buildpackutil
+
+
+def is_enabled():
+    return os.getenv('DD_API_KEY') is not None
+
+
+def _get_hostname():
+    domain = buildpackutil.get_vcap_data()['application_uris'][0].split('/')[0]
+    return domain + '-' + os.getenv('CF_INSTANCE_INDEX', '')
+
+
+def update_config(m2ee, app_name):
+    if not is_enabled():
+        return
+    m2ee.config._conf['m2ee']['javaopts'].extend([
+        '-Dcom.sun.management.jmxremote',
+        '-Dcom.sun.management.jmxremote.port=7845',
+        '-Dcom.sun.management.jmxremote.local.only=true',
+        '-Dcom.sun.management.jmxremote.authenticate=false',
+        '-Dcom.sun.management.jmxremote.ssl=false',
+        '-Djava.rmi.server.hostname=127.0.0.1',
+    ])
+    m2ee.config._conf['logging'].append({
+        'type': 'file',
+        'name': 'FileSubscriberDataDog',
+        'autosubscribe': 'INFO',
+        'filename': os.path.join(os.getcwd(), 'log', 'datadog.log'),
+        'max_size': 1048576,
+        'max_rotation': 1,
+    })
+# disable until mendix version has been released
+#    jar = os.path.abspath('.local/datadog/mx-agent-assembly-0.1-SNAPSHOT.jar')
+#    m2ee.config._conf['m2ee']['javaopts'].extend([
+#        '-javaagent:{}'.format(jar),
+#        '-Xbootclasspath/a:{}'.format(jar),
+#    ])
+    subprocess.check_call(('mkdir', '-p', '.local/datadog'))
+    with open('.local/datadog/datadog.yaml', 'w') as fh:
+        config = {
+            'dd_url': 'https://app.datadoghq.com',
+            'api_key': None,  # set via DD_API_KEY instead
+            'confd_path': '.local/datadog/conf.d',
+            'logs_enabled': True,
+            'log_file': '/dev/null',
+            'hostname': _get_hostname(),
+            'process_config': {
+                'enabled': 'true',  # has to be string
+                'log_file': '/dev/null',
+            },
+            'apm_config': {
+                'enabled': True,
+                'max_traces_per_second': 10,
+            },
+            'logs_config': {
+                'run_path': '.local/datadog/run',
+            },
+        }
+        fh.write(yaml.dump(config))
+    subprocess.check_call(('mkdir', '-p', '.local/datadog/conf.d/mendix.d'))
+    subprocess.check_call(('mkdir', '-p', '.local/datadog/run'))
+    with open('.local/datadog/conf.d/mendix.d/conf.yaml', 'w') as fh:
+        config = {
+            'logs': [{
+                'type': 'file',
+                'path': 'log/datadog.log',
+                'service': _get_hostname(),
+                'source': 'mendix',
+                'sourcecategory': 'sourcecode',
+                'tags': 'env:prod',
+            }],
+        }
+        fh.write(yaml.dump(config))
+    subprocess.check_call(('mkdir', '-p', '.local/datadog/conf.d/jmx.d'))
+    with open('.local/datadog/conf.d/jmx.d/conf.yaml', 'w') as fh:
+        config = {
+            'init_config': {
+                'collect_default_metrics': True,
+                'is_jmx': True,
+            },
+            'instances': [{
+                'host': 'localhost',
+                'port': 7845,
+                'java_bin_path': '.local/bin/java',
+            }],
+        }
+        fh.write(yaml.dump(config))
+
+
+def compile(install_path, cache_dir):
+    if not is_enabled():
+        return
+    buildpackutil.download_and_unpack(
+        buildpackutil.get_blobstore_url(
+            '/mx-buildpack/experimental/dd-v0.6.tar.gz',
+        ),
+        os.path.join(install_path, 'datadog'),
+        cache_dir=cache_dir,
+    )
+
+
+def run():
+    if not is_enabled():
+        return
+    subprocess.Popen(('.local/datadog/dd-agent', '-c', '.local/datadog', 'start'))
+    e = dict(os.environ)
+    e['DD_HOSTNAME'] = _get_hostname()
+    subprocess.Popen(('.local/datadog/dd-process-agent', '-logtostderr', '-config', '.local/datadog/datadog.yaml'), env=e)

--- a/start.py
+++ b/start.py
@@ -130,16 +130,6 @@ def start_nginx():
     ])
 
 
-def get_vcap_data():
-    if os.environ.get('VCAP_APPLICATION'):
-        return json.loads(os.environ.get('VCAP_APPLICATION'))
-    else:
-        return {
-            'application_uris': ['example.com'],
-            'application_name': 'My App',
-        }
-
-
 def activate_license():
     prefs_dir = os.path.expanduser('~/../.java/.userPrefs/com/mendix/core')
     buildpackutil.mkdir_p(prefs_dir)
@@ -1011,7 +1001,7 @@ if __name__ == '__main__':
         )
     pre_process_m2ee_yaml()
     activate_license()
-    m2ee = set_up_m2ee_client(get_vcap_data())
+    m2ee = set_up_m2ee_client(buildpackutil.get_vcap_data())
 
     def sigterm_handler(_signo, _stack_frame):
         m2ee.stop()

--- a/start.py
+++ b/start.py
@@ -14,6 +14,7 @@ import traceback
 sys.path.insert(0, 'lib')
 import requests
 import buildpackutil
+import datadog
 import logging
 import instadeploy
 import datetime
@@ -681,6 +682,7 @@ def set_up_m2ee_client(vcap_data):
     activate_new_relic(m2ee, vcap_data['application_name'])
     activate_appdynamics(m2ee, vcap_data['application_name'])
     set_application_name(m2ee, vcap_data['application_name'])
+    datadog.update_config(m2ee, vcap_data['application_name'])
     return m2ee
 
 
@@ -1025,6 +1027,7 @@ if __name__ == '__main__':
     try:
         service_backups()
         set_up_nginx_files(m2ee)
+        datadog.run()
         complete_start_procedure_safe_to_use_for_restart(m2ee)
         set_up_instadeploy_if_deploy_password_is_set(m2ee)
         start_metrics(m2ee)


### PR DESCRIPTION
There are 4 main changes:
- add an agent which opens up statsd / opentracing endpoints, the
runtime can start to send metrics there
- add log subscriber on the runtime, the dd agent tails that file
- enable JMX on the mendix app, so JVM metrics are visible in datadog
- add a process agent, so all container processes CPU / max open files
stats etc are visible in datadog

All of this is currently in alpha and only activated after enabling
DD_API_KEY.