### PR TITLE
Better logging in tests

### DIFF
--- a/tests/create-app-services.sh
+++ b/tests/create-app-services.sh
@@ -3,7 +3,6 @@
 pids=""
 RESULT=0
 APPNAME=$1
-export CF_TRACE=true
 
 cf create-service schnapps-testfree basic-testfree $APPNAME-schnapps 2>&1 &
 pids="$pids $!"

--- a/tests/usecase/basetest.py
+++ b/tests/usecase/basetest.py
@@ -142,8 +142,12 @@ class BaseTest(unittest.TestCase):
         effective_env = os.environ.copy()
         if env:
             effective_env.update(env)
-        return subprocess.check_output(
-            command,
-            stderr=subprocess.PIPE,
-            env=effective_env,
-        ).decode('utf-8')
+        try:
+            return subprocess.check_output(
+                command,
+                stderr=subprocess.PIPE,
+                env=effective_env,
+            ).decode('utf-8')
+        except subprocess.CalledProcessError as e:
+            print(e.output.decode('utf-8'))
+            raise


### PR DESCRIPTION
Always log the output of subprocess calls, this will help debugging non-deterministic tests.

~Based on #167, so do not merge until #167 is merged.~ That is now done.