### PR TITLE
Prefer TAGS over DD_TAGS which is less opinionated

### DIFF
--- a/lib/datadog.py
+++ b/lib/datadog.py
@@ -12,8 +12,9 @@ def _get_api_key():
 
 def _get_tags():
     return json.loads(
-        os.getenv('DD_TAGS', '[]')
-    )
+        os.getenv('TAGS', 
+            os.getenv('DD_TAGS', '[]')
+    ))
 
 
 def is_enabled():


### PR DESCRIPTION
For setting tags on the CF environment use a less opinionated variable name. This is related to CloudPortal changes for setting tags on environments.