### PR TITLE
Open model files using utf-8-sig encoding

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -33,7 +33,7 @@ logging.getLogger("requests").setLevel(logging.WARNING)
 def get_runtime_version():
     file_name = os.path.join(BUILD_DIR, 'model', 'metadata.json')
     try:
-        with open(file_name) as file_handle:
+        with codecs.open(file_name) as file_handle:
             data = json.loads(file_handle.read())
             return MXVersion(data['RuntimeVersion'])
     except IOError:

--- a/bin/compile
+++ b/bin/compile
@@ -33,7 +33,7 @@ logging.getLogger("requests").setLevel(logging.WARNING)
 def get_runtime_version():
     file_name = os.path.join(BUILD_DIR, 'model', 'metadata.json')
     try:
-        with codecs.open(file_name) as file_handle:
+        with open(file_name) as file_handle:
             data = json.loads(file_handle.read())
             return MXVersion(data['RuntimeVersion'])
     except IOError:

--- a/bin/compile
+++ b/bin/compile
@@ -33,7 +33,7 @@ logging.getLogger("requests").setLevel(logging.WARNING)
 def get_runtime_version():
     file_name = os.path.join(BUILD_DIR, 'model', 'metadata.json')
     try:
-        with codecs.open(file_name) as file_handle:
+        with codecs.open(file_name,'r', encoding='utf-8-sig') as file_handle:
             data = json.loads(file_handle.read())
             return MXVersion(data['RuntimeVersion'])
     except IOError:

--- a/lib/m2ee/config.py
+++ b/lib/m2ee/config.py
@@ -206,7 +206,8 @@ class M2EEConfig:
 
         config = None
         try:
-            config = json.load(fd, 'r', encoding='utf-8-sig')
+            codecs.open(file_name,'r', encoding='utf-8-sig') as file_handle
+            config = json.load(file_handle)
         except Exception as e:
             logger.error("Error parsing configuration file %s: %s" %
                          (jsonfile, e))

--- a/lib/m2ee/config.py
+++ b/lib/m2ee/config.py
@@ -206,7 +206,7 @@ class M2EEConfig:
 
         config = None
         try:
-            config = json.load(fd)
+            config = json.load(fd, 'r', encoding='utf-8-sig')
         except Exception as e:
             logger.error("Error parsing configuration file %s: %s" %
                          (jsonfile, e))

--- a/lib/m2ee/config.py
+++ b/lib/m2ee/config.py
@@ -11,6 +11,7 @@ import sys
 import pwd
 import re
 import copy
+import codecs
 
 from .log import logger
 from collections import defaultdict

--- a/lib/m2ee/config.py
+++ b/lib/m2ee/config.py
@@ -206,8 +206,8 @@ class M2EEConfig:
 
         config = None
         try:
-            codecs.open(file_name,'r', encoding='utf-8-sig') as file_handle
-            config = json.load(file_handle)
+            with codecs.open(file_name,'r', encoding='utf-8-sig') as file_handle:
+                config = json.load(file_handle)
         except Exception as e:
             logger.error("Error parsing configuration file %s: %s" %
                          (jsonfile, e))


### PR DESCRIPTION
-INCOMPLETE PULL REQUEST-
- Customer complains about builds failing with a "UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 3627: ordinal not in range(128)" error. 
- Little digging reveals python3 handles encoding differently by default (https://stackoverflow.com/questions/21129020/how-to-fix-unicodedecodeerror-ascii-codec-cant-decode-byte/21129492). 
- Problem seems fixed in the build phase by explicitly specifying utf-8-sig encoding of metadata.json file upon opening (encoding type is derived from opening of error file - line 254 of compile script)
- However, now that the build runs fine, the script throws decoding errors during the start phase while loading other files.
- I tried fixing these too, but solving one (in lib/m2ee/config.py) led to another one:
_ERROR: Error parsing configuration file /build/model/metadata.json: name 'file_name' is not defined
mendixapp_1  | ERROR: An error occured while trying to read mendix version number from model.mdp: file is encrypted or is not a database_
- Instead of spending more time on this, I figured it be better if somebody who knows these scripts&python better can verify if this is the proper approach and/or there is a smarter way to deal with this than manually changing all file opens.

====
Excerpt of initial build log on customer project:

 ---> Running in f28024e9303d
INFO: Mendix project compilation phase...
INFO: source push detected
INFO: Selecting Mono Runtime: mono-4.6.2.16

   __  __      ____        _ _     _
  |  \/  |    |  _ \      (_) |   | |
  | \  / |_  _| |_) |_   _ _| | __| |
  | |\/| \ \/ /  _ <| | | | | |/ _` |
  | |  | |>  <| |_) | |_| | | | (_| |
  |_|  |_/_/\_\____/ \__,_|_|_|\__,_|

   v7.15.1

Starting build for Mendix Project file: /build/xxx.mpr
Using the following options:
 * Build target: Package
 * Deployment package file: /tmp/model.mda
Reading project file...
Building project...
Executing step 'Synchronize with file system'
 * Synchronizing with file system...
Executing step 'Initialize'
 * Preparing deployment...
Executing step 'Check prerequisites'
 * Checking for errors...
Executing step 'Clean deployment directory'
 * Cleaning deployment directory...
 * Cleaning web deployment directory...
Executing step 'Prepare deployment'
 * Writing files...
Executing step 'Build deployment structure'
 * Compiling Java...
 * Generating integration files...
 * Exporting a theme...
 * Exporting pages...
 * Optimizing...
 * Exporting custom widgets...
 * Bundling custom widgets...
 * Compressing web resources...
Executing step 'Save model to deployment directory'
 * Saving model to deployment directory...
Executing step 'Create deployment package'
 * Creating deployment package...
Executing step 'Finalize deployment package'
BUILD SUCCEEDED
Traceback (most recent call last):
  File "/buildpack/bin/compile", line 289, in <module>
    set_up_java()
  File "/buildpack/bin/compile", line 88, in set_up_java
    get_runtime_version(), CACHE_DIR, DOT_LOCAL_LOCATION, package='jre'
  File "/buildpack/bin/compile", line 37, in get_runtime_version
    data = json.loads(file_handle.read())
  File "/usr/lib/python3.4/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 3627: ordinal not in range(128)
Removing intermediate container f28024e9303d