### PR TITLE
DEP-334: configure jetty options

### DIFF
--- a/start.py
+++ b/start.py
@@ -293,6 +293,19 @@ def set_jvm_memory(m2ee_section, vcap, java_version):
         )
 
 
+def set_jetty_config(m2ee):
+    jetty_config_json = os.environ.get('JETTY_CONFIG')
+    if not jetty_config_json:
+        return None
+    try:
+        jetty_config = json.loads(jetty_config_json)
+        jetty = m2ee.config._conf['m2ee']['jetty']
+        jetty.update(jetty_config)
+        logger.debug('Jetty configured: %s', json.dumps(jetty))
+    except Exception as e:
+        logger.warning('Failed to configure jetty', exc_info=True)
+
+
 def _get_s3_specific_config(vcap_services, m2ee):
     access_key = secret = bucket = encryption_keys = key_suffix = None
     endpoint = None
@@ -683,6 +696,7 @@ def set_up_m2ee_client(vcap_data):
         vcap_data,
         java_version,
     )
+    set_jetty_config(m2ee)
     activate_new_relic(m2ee, vcap_data['application_name'])
     activate_appdynamics(m2ee, vcap_data['application_name'])
     set_application_name(m2ee, vcap_data['application_name'])

--- a/tests/usecase/test_jetty_config.py
+++ b/tests/usecase/test_jetty_config.py
@@ -1,0 +1,21 @@
+import basetest
+import json
+
+
+class TestCaseJettyConfig(basetest.BaseTest):
+
+    def test_jetty_config(self):
+        self.setUpCF('sample-6.2.0.mda', env_vars={
+            'BUILDPACK_XTRACE': 'true',
+            'JETTY_CONFIG': json.dumps({"runtime_max_threads": 500}),
+        })
+        self.startApp()
+        self.assert_string_in_recent_logs('runtime_max_threads')
+        self.assert_string_in_recent_logs('max_form_content_size')
+
+    def test_invalid_jetty_config(self):
+        self.setUpCF('sample-6.2.0.mda', env_vars={
+            'JETTY_CONFIG': 'invalid json',
+        })
+        self.startApp()
+        self.assert_string_in_recent_logs('Failed to configure jetty')


### PR DESCRIPTION
Manually tested:

```
cf set-env 675bc0be-de1a-4cc9-b067-78f0c8540a82 JETTY_CONFIG '{"runtime_max_threads": 100}'

```

and restarted the app:

![screenshot 2018-06-28 at 13 33 24](https://user-images.githubusercontent.com/1109695/42032010-76ac447e-7ad8-11e8-86d0-f50cdbb056ad.png)
