### PR TITLE
Workaround telegraf basic auth issue by adding Authorization header

### DIFF
--- a/lib/telegraf.py
+++ b/lib/telegraf.py
@@ -11,10 +11,11 @@
 #     to custom end points
 #
 # Examples:
-# {"url: "https://customreceiver.mydomain.com", "username": "user", "password": secret", "kpionly": true}
-# [{"url: "https://customreceiver.mydomain.com", "username": "user", "password": secret", "kpionly": true}]
+# {"url": "https://customreceiver.mydomain.com", "username": "user", "password": "secret", "kpionly": true}
+# [{"url": "https://customreceiver.mydomain.com", "username": "user", "password": "secret", "kpionly": true}]
 #
 
+import base64
 import json
 import os
 
@@ -103,8 +104,13 @@ def _write_http_output_config(http_config):
     username = http_config.get('username')
     password = http_config.get('password')
     if username is not None:
-        http_output['username'] = username
-        http_output['password'] = password
+        # Workaround for https://github.com/influxdata/telegraf/issues/4544
+        # http_output['username'] = username
+        # http_output['password'] = password
+        credentials = base64.b64encode(('%s:%s' % (username, password)).encode()).decode('ascii')
+        http_output['[outputs.http.headers]'] = {
+            'Authorization': 'Basic ' + credentials
+        }
 
     kpionly = http_config['kpionly'] if 'kpionly' in http_config else True
     if kpionly:

--- a/start.py
+++ b/start.py
@@ -27,7 +27,7 @@ from buildpackutil import i_am_primary_instance  # noqa: E402
 logger.setLevel(buildpackutil.get_buildpack_loglevel())
 
 
-logger.info('Started Mendix Cloud Foundry Buildpack v2.0.3')
+logger.info('Started Mendix Cloud Foundry Buildpack v2.1.2')
 
 logging.getLogger('m2ee').propagate = False
 


### PR DESCRIPTION
There is an issue with adding the authorization header to Telegraf. This is filed as https://github.com/influxdata/telegraf/issues/4544. Workaround is adding Authorization as custom header. 