### PR TITLE
Disable logging when posting to trends-storage-server fails.

### DIFF
--- a/lib/metrics.py
+++ b/lib/metrics.py
@@ -35,6 +35,9 @@ class MetricsServerEmitter(MetricsEmitter):
         try:
             response = requests.post(self.metrics_url, json=stats, timeout=10)
         except Exception as e:
+            logger.debug(
+                "Failed to send metrics to trends server.", exc_info=True
+            )
             # Fallback to old pipeline and stdout for now.
             # Later, we will want to buffer and resend.
             # This will be done in DEP-75.
@@ -42,11 +45,19 @@ class MetricsServerEmitter(MetricsEmitter):
             return
 
         if response.status_code != 200:
+            logger.debug(
+                "Failed to send metrics to trends server. Falling back to old "
+                "loggregator based method. Got status code %s "
+                "for URL %s, with body %s.",
+                response.status_code,
+                self.metrics_url,
+                response.text,
+            )
+
             self.fallback_emitter.emit(stats)
 
 
 class MetricsEmitterThread(threading.Thread):
-
     def __init__(self, interval, m2ee):
         super(MetricsEmitterThread, self).__init__()
         self.interval = interval

--- a/lib/metrics.py
+++ b/lib/metrics.py
@@ -35,8 +35,6 @@ class MetricsServerEmitter(MetricsEmitter):
         try:
             response = requests.post(self.metrics_url, json=stats, timeout=10)
         except Exception as e:
-            logger.warning("Failed to send metrics to trends server.",
-                           exc_info=True)
             # Fallback to old pipeline and stdout for now.
             # Later, we will want to buffer and resend.
             # This will be done in DEP-75.
@@ -44,12 +42,6 @@ class MetricsServerEmitter(MetricsEmitter):
             return
 
         if response.status_code != 200:
-            logger.warning(
-                "Failed to send metrics to trends server. Falling back to old "
-                "loggregator based method. Got status code %s "
-                "for URL %s, with body %s.",
-                response.status_code, self.metrics_url, response.text)
-
             self.fallback_emitter.emit(stats)
 
 

--- a/start.py
+++ b/start.py
@@ -27,7 +27,7 @@ from buildpackutil import i_am_primary_instance  # noqa: E402
 logger.setLevel(buildpackutil.get_buildpack_loglevel())
 
 
-logger.info('Started Mendix Cloud Foundry Buildpack v2.0.3')
+logger.info("Started Mendix Cloud Foundry Buildpack v2.0.4")
 
 logging.getLogger('m2ee').propagate = False
 

--- a/tests/usecase/test_emit_metrics.py
+++ b/tests/usecase/test_emit_metrics.py
@@ -20,12 +20,16 @@ class TestCaseEmitMetrics(basetest.BaseTest):
 
 class TestNewMetricsFlows(basetest.BaseTest):
     def test_fallback_flow_when_server_unreachable(self):
-        self.setUpCF('sample-6.2.0.mda', env_vars={
-            'METRICS_INTERVAL': '10',
-            'BYPASS_LOGGREGATOR': 'True',
-            # This should always 404:
-            'TRENDS_STORAGE_URL': 'https://example.com/a_fake_path'
-        })
+        self.setUpCF(
+            "sample-6.2.0.mda",
+            env_vars={
+                "METRICS_INTERVAL": "10",
+                "BYPASS_LOGGREGATOR": "True",
+                # This should always 404:
+                "TRENDS_STORAGE_URL": "https://example.com/a_fake_path",
+                "BUILDPACK_XTRACE": "true",
+            },
+        )
         self.startApp()
 
         time.sleep(10)


### PR DESCRIPTION
Currently, customers end up with this message in their logs in cases
where there is no data loss. This causes unnecessary confusion.

We will replace this logging with grafana monitoring (DEP-87), and in
the long run, we should also allow the buildpack to send exceptions that
shouldn't be exposed to the customer via Sentry, so we can diagnose
them.