### PR TITLE
Added support for Azure PostgreSQL credential formats

### DIFF
--- a/lib/buildpackutil.py
+++ b/lib/buildpackutil.py
@@ -113,6 +113,10 @@ def get_database_uri_from_vcap():
         'rds',
         'postgresql_shared',
     ):
+        if 'azure-postgresqldb' in vcap_services:
+            credentials = vcap_services['azure-postgresqldb'][0]['credentials']
+            return 'postgresql://' + credentials['username'] + ':' + credentials['password'] + '@' + credentials['hostname'] + ':' + str(credentials['port']) + '/' + credentials['postgresqlDatabaseName'] + '?sslmode=require'
+
         if vcap_services and service_type_name in vcap_services:
             return vcap_services[service_type_name][0]['credentials']['uri']
     if 'azure-sqldb' in vcap_services:


### PR DESCRIPTION
Fixes #194

## Overview

The azure service broker generates a username with `@` characters. The `jdbcUrl` is parsed by the Mendix Buildpack python compile script. Then, it rebuilds a config object

## Problem

The values found in `jdbcUrl` are URI encoded. Values that are configured in the config dictionary for m2e are not supposed to be encoded as a URI format is not expected.

## Fix implementation

The database URL expected by the buildpack must not contain encoded values.  `buildpackutil.lib` now builds an URL from the non-encoded fields of the credential blob from `VCAP_SERVICES` when an azure postgresql database is identified.