### PR TITLE
DO: add DEBUG_CONTAINER mode

### DIFF
--- a/tests/usecase/test_debug_container.py
+++ b/tests/usecase/test_debug_container.py
@@ -1,0 +1,31 @@
+import basetest
+import requests
+
+
+class TestCaseDebugContainer(basetest.BaseTest):
+    def setUp(self):
+        self.setUpCF(
+            "BuildpackTestApp-mx-7-16.mda",
+            env_vars={"DEBUG_CONTAINER": "true"},
+        )
+        self.startApp()
+
+    def _assert_maintenance(self, response):
+        assert response.status_code == 503
+        assert "X-Mendix-Cloud-Mode" in response.headers
+        assert response.headers["X-Mendix-Cloud-Mode"] == "maintenance"
+        assert "App is in maintenance mode" in response.text
+
+    def test_maintenance_mode(self):
+        self.assert_app_running(code=503)
+        self.assert_string_in_recent_logs("App is in maintenance mode")
+
+    def test_maintenance_get(self):
+        full_uri = "https://" + self.app_name + "/index.html"
+        r = requests.get(full_uri)
+        self._assert_maintenance(r)
+
+    def test_maintenance_post(self):
+        full_uri = "https://" + self.app_name + "/xas/"
+        r = requests.get(full_uri)
+        self._assert_maintenance(r)


### PR DESCRIPTION
This mode allows operators to start an application for troubleshooting the container. This saved a lot of time figuring out why the app was crashing with exit status code 143.