### PR TITLE
Change metric_separator to be compatible with DataDog

### DIFF
--- a/lib/telegraf.py
+++ b/lib/telegraf.py
@@ -167,7 +167,7 @@ def update_config(m2ee, app_name):
             "delete_sets": True,
             "delete_timings": True,
             "percentiles": [90],
-            "metric_separator": "_",
+            "metric_separator": ".",
             "parse_data_dog_tags": True,
             "allowed_pending_messages": 10000,
             "percentile_limit": 1000,

--- a/start.py
+++ b/start.py
@@ -53,7 +53,7 @@ HEARTBEAT_STRING_LIST = codecs.encode(HEARTBEAT_SOURCE_STRING, "rot13").split(
 )
 
 logger.setLevel(buildpackutil.get_buildpack_loglevel())
-logger.info("Started Mendix Cloud Foundry Buildpack v2.2.1")
+logger.info("Started Mendix Cloud Foundry Buildpack v2.2.2")
 logging.getLogger("m2ee").propagate = False
 
 


### PR DESCRIPTION
Change metric_separator from underscore to dot to be aligned with DataDog when Telegraf is used to forward statsd metrics.