### PR TITLE
support for running a Mendix app without routes

### DIFF
--- a/start.py
+++ b/start.py
@@ -226,7 +226,7 @@ def activate_license():
 
 def get_application_root_url(vcap_data):
     try:
-        return "https://%s" % vcap_data["application_uris"][0]
+        return "https://{}".format(vcap_data["application_uris"][0])
     except IndexError:
         logger.warning("ApplicationRootUrl can't be configured, no application routes are defined.")
         return ""

--- a/start.py
+++ b/start.py
@@ -224,6 +224,14 @@ def activate_license():
             prefs_file.write(prefs_body)
 
 
+def get_application_root_url(vcap_data):
+    try:
+        return "https://%s" % vcap_data["application_uris"][0]
+    except IndexError:
+        logger.warning("ApplicationRootUrl can't be configured, no application routes are defined.")
+        return ""
+
+
 def get_scheduled_events(metadata):
     scheduled_events = os.getenv("SCHEDULED_EVENTS", None)
     if not i_am_primary_instance():
@@ -629,7 +637,7 @@ def set_runtime_config(metadata, mxruntime_config, vcap_data, m2ee):
         metadata
     )
     app_config = {
-        "ApplicationRootUrl": "https://%s" % vcap_data["application_uris"][0],
+        "ApplicationRootUrl": get_application_root_url(vcap_data),
         "MicroflowConstants": get_constants(metadata),
         "ScheduledEventExecution": scheduled_event_execution,
     }

--- a/start.py
+++ b/start.py
@@ -228,7 +228,10 @@ def get_application_root_url(vcap_data):
     try:
         return "https://{}".format(vcap_data["application_uris"][0])
     except IndexError:
-        logger.warning("ApplicationRootUrl can't be configured, no application routes are defined.")
+        logger.warning(
+            "No application routes are defined. Your application will not be "
+            "accessible. Please contact support if this issue persists."
+        )
         return ""
 
 


### PR DESCRIPTION
When trying to start a Mendix app using this buildpack, before this
commit you got this error and your app was not able to start:

> INFO: Started Mendix Cloud Foundry Buildpack vX.Y.Z
> Traceback (most recent call last):
>   File "start.py", line 1207, in <module>
>     m2ee = set_up_m2ee_client(buildpackutil.get_vcap_data())
>   File "start.py", line 811, in set_up_m2ee_client
>     m2ee,
>   File "start.py", line 632, in set_runtime_config
>     "ApplicationRootUrl": "https://%s" % vcap_data["application_uris"][0],
> IndexError: list index out of range
> Terminated

This commit adds support for running a Mendix app without having any
routes mapped to this application.