### PR TITLE
CLDOPS-2680: increase proxy_read_timeout to 1h

### DIFF
--- a/nginx/conf/proxy_params
+++ b/nginx/conf/proxy_params
@@ -1,6 +1,6 @@
 # Nginx Backend Web Server
 
-proxy_read_timeout 15m;
+proxy_read_timeout 1h;
 proxy_http_version 1.1;
 proxy_set_header Host $host;
 

--- a/start.py
+++ b/start.py
@@ -53,7 +53,7 @@ HEARTBEAT_STRING_LIST = codecs.encode(HEARTBEAT_SOURCE_STRING, "rot13").split(
 )
 
 logger.setLevel(buildpackutil.get_buildpack_loglevel())
-logger.info("Started Mendix Cloud Foundry Buildpack v2.2.4")
+logger.info("Started Mendix Cloud Foundry Buildpack v2.2.5")
 logging.getLogger("m2ee").propagate = False
 
 


### PR DESCRIPTION
This is the same value that our frontfacing layer has set.
Putting it lower (eg. 15m) results in this when exceeding:

[error] 191#0: *82 upstream timed out (110: Connection timed out) while
reading response header from upstream

See also: https://stackoverflow.com/a/46205792/1007729