### PR TITLE
DEP-758 Enable DataDog stasd listener besides Telegraf 

### DIFF
--- a/lib/datadog.py
+++ b/lib/datadog.py
@@ -71,7 +71,10 @@ def update_config(m2ee, app_name):
         return
 
     tags = buildpackutil.get_tags()
-    statsd_port = 8125 if not buildpackutil.is_appmetrics_enabled() else 8126
+    if buildpackutil_is_appmetrics_enabled():
+        statsd_port = 8126
+    else:
+        statsd_port = 8125
     m2ee.config._conf["m2ee"]["javaopts"].extend(
         [
             "-Dcom.sun.management.jmxremote",

--- a/lib/datadog.py
+++ b/lib/datadog.py
@@ -71,6 +71,7 @@ def update_config(m2ee, app_name):
         return
 
     tags = buildpackutil.get_tags()
+    statsd_port = 8125 if not buildpackutil.is_appmetrics_enabled() else 8126
     m2ee.config._conf["m2ee"]["javaopts"].extend(
         [
             "-Dcom.sun.management.jmxremote",
@@ -108,7 +109,8 @@ def update_config(m2ee, app_name):
             },
             "apm_config": {"enabled": True, "max_traces_per_second": 10},
             "logs_config": {"run_path": ".local/datadog/run"},
-            "use_dogstatsd": not buildpackutil.is_appmetrics_enabled(),
+            "use_dogstatsd": True,
+            "dogstatsd_port": statsd_port,
         }
         fh.write(yaml.safe_dump(config))
     subprocess.check_call(("mkdir", "-p", ".local/datadog/conf.d/mendix.d"))
@@ -141,6 +143,7 @@ def update_config(m2ee, app_name):
                     "port": 7845,
                     "java_bin_path": ".local/bin/java",
                     "java_options": "-Xmx50m -Xms5m",
+                    "reporter": "statsd:localhost:{}".format(statsd_port),
                     # 'refresh_beans': 10, # runtime takes time to initialize the beans
                     "conf": [
                         {

--- a/lib/datadog.py
+++ b/lib/datadog.py
@@ -71,7 +71,7 @@ def update_config(m2ee, app_name):
         return
 
     tags = buildpackutil.get_tags()
-    if buildpackutil_is_appmetrics_enabled():
+    if buildpackutil.is_appmetrics_enabled():
         statsd_port = 8126
     else:
         statsd_port = 8125

--- a/start.py
+++ b/start.py
@@ -53,7 +53,7 @@ HEARTBEAT_STRING_LIST = codecs.encode(HEARTBEAT_SOURCE_STRING, "rot13").split(
 )
 
 logger.setLevel(buildpackutil.get_buildpack_loglevel())
-logger.info("Started Mendix Cloud Foundry Buildpack v2.2.5")
+logger.info("Started Mendix Cloud Foundry Buildpack v2.2.6")
 logging.getLogger("m2ee").propagate = False
 
 


### PR DESCRIPTION
Enable DataDog stasd listener besides Telegraf to support Service Check Events from JMXFetch. Related to DEP-758.