### PR TITLE
DEP-1112: Include git commit hash in buildpack logging.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -57,6 +57,32 @@ def check_environment_variable(variable, explanation):
         return True
 
 
+def get_current_git_commit():
+    try:
+        raw_commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=BUILDPACK_DIR
+        )
+        commit = raw_commit.decode("utf-8").strip()
+        short_commit = commit[:7]
+        return short_commit
+    except Exception:
+        logging.warning(
+            "MENDIX BUILDPACK: Unable to determine exact version "
+            "in use. This is nothing to worry about",
+            exc_info=True,
+        )
+        return "unknown_commit"
+
+
+def write_current_git_commit():
+    short_commit = get_current_git_commit()
+    with open(
+        os.path.join(BUILD_DIR, ".buildpack_commit"), "w"
+    ) as version_file:
+        logging.debug("Building with commit %s", short_commit)
+        version_file.write(short_commit)
+
+
 def set_up_appdynamics():
     if buildpackutil.appdynamics_used():
         buildpackutil.download_and_unpack(
@@ -293,5 +319,6 @@ if __name__ == '__main__':
     datadog.compile(DOT_LOCAL_LOCATION, CACHE_DIR)
     download_mendix_version()
     copy_buildpack_resources()
+    write_current_git_commit()
     set_up_nginx()
     logging.info('buildpack compile completed')

--- a/start.py
+++ b/start.py
@@ -54,9 +54,22 @@ HEARTBEAT_STRING_LIST = codecs.encode(HEARTBEAT_SOURCE_STRING, "rot13").split(
 
 logger.setLevel(buildpackutil.get_buildpack_loglevel())
 
-logger.info("Started Mendix Cloud Foundry Buildpack v2.2.5")
-logging.getLogger("m2ee").propagate = False
 
+def get_current_buildpack_commit():
+    try:
+        with open(".buildpack_commit", "r") as commit_file:
+            short_commit = commit_file.readline().strip()
+            return short_commit
+    except Exception:
+        logger.debug("Failed to read file", exc_info=True)
+        return "unknown_commit"
+
+
+logger.info(
+    "Started Mendix Cloud Foundry Buildpack v2.2.6 [commit:%s]",
+    get_current_buildpack_commit(),
+)
+logging.getLogger("m2ee").propagate = False
 
 app_is_restarting = False
 default_m2ee_password = str(uuid.uuid4()).replace("-", "@") + "A1"

--- a/tests/usecase/test_logging.py
+++ b/tests/usecase/test_logging.py
@@ -1,5 +1,7 @@
-import basetest
 import json
+import os
+
+import basetest
 
 
 class TestCaseLogging(basetest.BaseTest):
@@ -14,3 +16,9 @@ class TestCaseLogging(basetest.BaseTest):
     def test_logging_config(self):
         self.assert_app_running()
         self.assert_string_in_recent_logs("TRACE - Jetty")
+
+    def test_commit_hash_in_logs(self):
+        commit_hash = os.getenv("TRAVIS_COMMIT")
+        if commit_hash:
+            short_commit_hash = commit_hash[:7]
+            self.assert_string_in_recent_logs(short_commit_hash)


### PR DESCRIPTION
FYI, further to our discussion this morning, I have chosen not to include the branch name in the logging.

This is because the branch name is not a canonical reference, whereas a commit hash is. A single commit can exist in many branches, and thus the information is superfluous. The only information you need to identify the code at a given point in time is the commit hash.

Furthermore, customers should only ever be running the master branch, not any other branch. Nobody should ever force push to master (and indeed, this should be a protected branch in the repository), thus commit hashes in master should never change.

In the future, I indent for this code to be superseded by a more robust solution. This is described in DEP-1111.