### PR TITLE
CLDOPS-3676: Supress logging in case of failure to collect metrics.

### DIFF
--- a/lib/metrics.py
+++ b/lib/metrics.py
@@ -98,7 +98,11 @@ class MetricsEmitterThread(threading.Thread):
                     stats = self._inject_database_stats(stats)
                     stats = self._inject_storage_stats(stats)
                     stats = self._inject_health(stats)
-                stats = self._inject_m2ee_stats(stats)
+                try:
+                    stats = self._inject_m2ee_stats(stats)
+                except Exception:
+                    logger.debug("Unable to get metrics from runtime")
+
                 self.emit(stats)
             except psycopg2.OperationalError as up:
                 logger.exception("METRICS: error while gathering metrics")


### PR DESCRIPTION
Customers complain about this a lot. However, it is my assessment that
our customers are only complaining because of the presence of a message
that contains the word error - they do not experience degraded
functionality of their application. Thus, to ensure our customers only
receive "error" messages when something actionable is wrong, I am
surpressing this error message.