### PR TITLE
Add option for database connection parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ Now we need to push the application once more.
 
 You can now log in to your application with the configured admin password.
 
+For PostgreSQL we support setting additional parameters in the connection uri retrieved from the VCAP. To set additional JDBC parameters set the `DATABASE_CONNECTION_PARAMS` environment variable as JSON key-value string.
+
+```
+cf set-env <YOUR_APP> DATABASE_CONNECTION_PARAMS '{"tcpKeepAlive": "true", "connectionTimeout": 30, "loginTimeout": 15}'
+```
+
+Note: if you set `DATABASE_URL` provide it as JDBC connection string (prefixed with `jdbc:` and including parameters, `DATABASE_CONNECTION_PARAMS` is not needed then.
+
 
 ### Configuring Constants
 
@@ -358,7 +366,7 @@ If you use the `cf push` commands as described above, you will always use the la
 
 However, if you need to exercise a high degree of control over your deployments, it is possible to pin a specific version of the buildpack. This will prevent you from being affected by bugs that are inadvertently introduced, but you will need to set up a procedure to regularly move to new versions of the buildpack.
 
-To push with a specific version of the buildpack, append `#<tag>` to the buildpack URL in your `cf push` command like so: 
+To push with a specific version of the buildpack, append `#<tag>` to the buildpack URL in your `cf push` command like so:
 
     cf push <YOUR_APP> -b https://github.com/mendix/cf-mendix-buildpack#v1.9.2 -p <YOUR_MDA>.mda -t 180
 

--- a/start.py
+++ b/start.py
@@ -66,7 +66,7 @@ def get_current_buildpack_commit():
 
 
 logger.info(
-    "Started Mendix Cloud Foundry Buildpack v2.2.8 [commit:%s]",
+    "Started Mendix Cloud Foundry Buildpack v2.2.10 [commit:%s]",
     get_current_buildpack_commit(),
 )
 logging.getLogger("m2ee").propagate = False

--- a/tests/usecase/basetest.py
+++ b/tests/usecase/basetest.py
@@ -29,13 +29,17 @@ class BaseTest(unittest.TestCase):
             ).decode("utf-8")
         else:
             current_branch = "master"
+        self.branch_name = os.environ.get("TRAVIS_BRANCH", current_branch)
+
         self.cf_domain = os.environ.get("CF_DOMAIN")
         assert self.cf_domain
         self.buildpack_repo = os.environ.get(
             "BUILDPACK_REPO",
             "https://github.com/mendix/cf-mendix-buildpack.git",
         )
-        self.branch_name = os.environ.get("TRAVIS_BRANCH", current_branch)
+        self.buildpack = os.environ.get(
+            "BUILDPACK", "{}#{}".format(self.buildpack_repo, self.branch_name)
+        )
         self.mx_password = os.environ.get("MX_PASSWORD", "Y0l0lop13#123")
         self.app_id = str(uuid.uuid4()).split("-")[0]
         self.subdomain = "ops-" + self.app_id
@@ -133,7 +137,7 @@ class BaseTest(unittest.TestCase):
                     "-i",
                     str(instances),
                     "-b",
-                    ("%s#%s" % (self.buildpack_repo, self.branch_name)),
+                    self.buildpack,
                 )
             )
         except subprocess.CalledProcessError as e:

--- a/tests/usecase/test_jdbc_parameters.py
+++ b/tests/usecase/test_jdbc_parameters.py
@@ -1,0 +1,42 @@
+import basetest
+import json
+
+
+class TestJdbcParameters(basetest.BaseTest):
+    def setUp(self):
+        super().setUp()
+
+    def test_default_jdbc_parameters(self):
+        self.setUpCF("BuildpackTestApp-mx-7-16.mda", health_timeout=60)
+        self.startApp()
+        self.assert_string_in_recent_logs("?tcpKeepAlive=true")
+
+    def test_default_jdbc_parameters_7_23_1(self):
+        self.setUpCF("AdoptOpenJDKTest_7.23.1.mda", health_timeout=60)
+        self.startApp()
+        self.assert_string_in_recent_logs("?tcpKeepAlive=true")
+
+    def test_overwrite_default(self):
+        self.setUpCF(
+            "BuildpackTestApp-mx-7-16.mda",
+            health_timeout=60,
+            env_vars={
+                "DATABASE_CONNECTION_PARAMS": json.dumps(
+                    {"tcpKeepAlive": "false", "connectionTimeout": 30}
+                )
+            },
+        )
+        self.startApp()
+        self.assert_string_in_recent_logs("tcpKeepAlive=false")
+        self.assert_string_in_recent_logs("connectionTimeout=30")
+
+    def test_invalid_jdbc_parameters(self):
+        self.setUpCF(
+            "BuildpackTestApp-mx-7-16.mda",
+            health_timeout=60,
+            env_vars={"DATABASE_CONNECTION_PARAMS": '{"tcpKeepAlive: "true"}'},
+        )
+        self.startApp()
+        self.assert_string_in_recent_logs(
+            "Invalid JSON string for DATABASE_CONNECTION_PARAMS"
+        )


### PR DESCRIPTION
For Postgres additional connection parameters need to be set to properly configure database connection for AZ fail over. To do this the runtime need to get JDBC string instead of separate parameters. This change set the JDBC string for PostgreSQL and allows to add or overwrite JDBC parameters on the VCAP database url. 
