### PR TITLE
Update nginx configuration to support 8k headers 

### DIFF
--- a/nginx/conf/proxy_params
+++ b/nginx/conf/proxy_params
@@ -4,6 +4,9 @@ proxy_read_timeout 1h;
 proxy_http_version 1.1;
 proxy_set_header Host $host;
 
+proxy_buffers 4 8k;
+proxy_buffer_size 8k;
+
 # These are only set on a backend web server
 set_real_ip_from 10.0.0.0/8;
 

--- a/start.py
+++ b/start.py
@@ -66,7 +66,7 @@ def get_current_buildpack_commit():
 
 
 logger.info(
-    "Started Mendix Cloud Foundry Buildpack v2.2.13 [commit:%s]",
+    "Started Mendix Cloud Foundry Buildpack v2.2.14 [commit:%s]",
     get_current_buildpack_commit(),
 )
 logging.getLogger("m2ee").propagate = False


### PR DESCRIPTION
Align accepted header sizes between nginx configuration and the Mendix runtime. Sending and receiving headers exceeding 4k was not possible via nginx. 