### PR TITLE
URLDecode database username

### DIFF
--- a/lib/database_config.py
+++ b/lib/database_config.py
@@ -4,7 +4,7 @@ import os
 import re
 import buildpackutil
 from abc import abstractmethod, ABC
-from urllib.parse import parse_qs, urlencode
+from urllib.parse import parse_qs, urlencode, unquote
 from m2ee import logger  # noqa: E402
 
 
@@ -243,7 +243,7 @@ class UrlDatabaseConfiguration(DatabaseConfiguration):
 
         config = {
             "DatabaseType": database_type,
-            "DatabaseUserName": match.group("user"),
+            "DatabaseUserName": urllib.parse.unquote(match.group("user")),
             "DatabasePassword": match.group("password"),
             "DatabaseHost": match.group("host"),
             "DatabaseName": match.group("dbname"),

--- a/lib/database_config.py
+++ b/lib/database_config.py
@@ -243,7 +243,7 @@ class UrlDatabaseConfiguration(DatabaseConfiguration):
 
         config = {
             "DatabaseType": database_type,
-            "DatabaseUserName": urllib.parse.unquote(match.group("user")),
+            "DatabaseUserName": unquote(match.group("user")),
             "DatabasePassword": match.group("password"),
             "DatabaseHost": match.group("host"),
             "DatabaseName": match.group("dbname"),


### PR DESCRIPTION
The username passed in the URI parameter in VCAP_SERVICES may contain a @ character, which is URL encoded as %40. Hence, usernames should always be URL decoded. If this is working, the runtime will also support Cloud Platform scenario's, in which a connection to Azure PostgreSQL database is made using the Open Service Broker.