### PR TITLE
double nginx worker connections

### DIFF
--- a/nginx/conf/nginx.conf
+++ b/nginx/conf/nginx.conf
@@ -1,4 +1,4 @@
-worker_processes 1;
+worker_processes auto;
 daemon off;
 
 error_log stderr;
@@ -29,17 +29,17 @@ http {
 
     upstream mendix {
         server 127.0.0.1:RUNTIME_PORT;
-        keepalive 16;
+        keepalive 8;
     }
 
     upstream mendix_admin {
         server 127.0.0.1:ADMIN_PORT;
-        keepalive 16;
+        keepalive 8;
     }
 
     upstream mendix_mxbuild {
         server 127.0.0.1:DEPLOY_PORT;
-        keepalive 16;
+        keepalive 8;
     }
 
     server {

--- a/nginx/conf/nginx.conf
+++ b/nginx/conf/nginx.conf
@@ -1,8 +1,8 @@
-worker_processes auto;
+worker_processes 1;
 daemon off;
 
 error_log stderr;
-events { worker_connections 4096; }
+events { worker_connections 8192; }
 
 http {
     XFRAMEOPTIONS

--- a/nginx/conf/nginx.conf
+++ b/nginx/conf/nginx.conf
@@ -29,17 +29,17 @@ http {
 
     upstream mendix {
         server 127.0.0.1:RUNTIME_PORT;
-        keepalive 8;
+        keepalive 16;
     }
 
     upstream mendix_admin {
         server 127.0.0.1:ADMIN_PORT;
-        keepalive 8;
+        keepalive 16;
     }
 
     upstream mendix_mxbuild {
         server 127.0.0.1:DEPLOY_PORT;
-        keepalive 8;
+        keepalive 16;
     }
 
     server {


### PR DESCRIPTION
This is being done to alleviate the 502 we're seeing. In our test environment this change helped and would like to give this a try. In the past (commit: cbefabdcb3ce96122a12dd39e23351a989f5be00) this was done for the exact same reason.

I'm not sure how's the release process for the cf-mendix-buildpack but I'd like to get this merged and deployed in the nonprod-1 environment and Free Apps cluster to verify how this change behaves under load. 