### PR TITLE
Disable the locale provider override for Java 11

### DIFF
--- a/start.py
+++ b/start.py
@@ -334,8 +334,8 @@ def get_constants(metadata):
 def set_jvm_locale(m2ee_section, java_version):
     javaopts = m2ee_section["javaopts"]
 
-    # enable locale for java8 or later
-    if not java_version.startswith("7"):
+    # override locale providers for java8
+    if java_version.startswith("8"):
         javaopts.append("-Djava.locale.providers=JRE,SPI,CLDR")
 
 


### PR DESCRIPTION
For Mendix 8 with Java 11 we are switching back to the default value of the locale providers, so the override should only apply for Java 8.

Mx 6 and 7 => Java 8 => apply override
Mx 8 => Java 11 => do not apply override anymore

(DEP-1791)