### PR TITLE
DVAS-326: Pushing sessions metrics for free apps

### DIFF
--- a/lib/buildpackutil.py
+++ b/lib/buildpackutil.py
@@ -473,5 +473,5 @@ def get_metrics_url():
     return os.getenv("TRENDS_STORAGE_URL")
 
 
-def is_paid_app():
-    return os.getenv("PROFILE") != "free"
+def is_free_app():
+    return os.getenv("PROFILE") == "free"

--- a/lib/buildpackutil.py
+++ b/lib/buildpackutil.py
@@ -471,3 +471,7 @@ def bypass_loggregator_logging():
 
 def get_metrics_url():
     return os.getenv("TRENDS_STORAGE_URL")
+
+
+def is_paid_app():
+    return os.getenv("PROFILE") != "free"

--- a/lib/metrics.py
+++ b/lib/metrics.py
@@ -102,7 +102,7 @@ class MetricsEmitterThread(threading.Thread):
 
                 if (
                     buildpackutil.i_am_primary_instance()
-                    and buildpackutil.is_paid_app()
+                    and not buildpackutil.is_free_app()
                 ):
                     stats = self._inject_database_stats(stats)
                     stats = self._inject_storage_stats(stats)
@@ -184,7 +184,7 @@ class MetricsEmitterThread(threading.Thread):
         if "sessions" in m2ee_stats:
             m2ee_stats["sessions"]["user_sessions"] = {}
             # Only push sessions metrics for free apps
-            if not buildpackutil.is_paid_app():
+            if buildpackutil.is_free_app():
                 return m2ee_stats["sessions"]
         m2ee_stats = munin.augment_and_fix_stats(
             m2ee_stats, self.m2ee.runner.get_pid(), java_version

--- a/start.py
+++ b/start.py
@@ -1216,15 +1216,14 @@ def set_up_instadeploy_if_deploy_password_is_set(m2ee):
 
 def start_metrics(m2ee):
     metrics_interval = os.getenv("METRICS_INTERVAL")
-    profile = os.getenv("PROFILE")
-    if metrics_interval and profile != "free":
+    if metrics_interval:
         import metrics
 
         thread = metrics.MetricsEmitterThread(int(metrics_interval), m2ee)
         thread.setDaemon(True)
         thread.start()
     else:
-        logger.info("MENDIX-INTERNAL: Metrics are disabled.")
+        logger.info("MENDIX-INTERVAL not set: Metrics are disabled.")
 
 
 class LoggingHeartbeatEmitterThread(threading.Thread):

--- a/start.py
+++ b/start.py
@@ -1223,7 +1223,7 @@ def start_metrics(m2ee):
         thread.setDaemon(True)
         thread.start()
     else:
-        logger.info("MENDIX-INTERVAL not set: Metrics are disabled.")
+        logger.info("MENDIX-INTERNAL: Metrics are disabled.")
 
 
 class LoggingHeartbeatEmitterThread(threading.Thread):

--- a/tests/usecase/test_emit_metrics.py
+++ b/tests/usecase/test_emit_metrics.py
@@ -15,6 +15,21 @@ class TestCaseEmitMetrics(basetest.BaseTest):
         self.assert_string_in_recent_logs("number_of_files")
         self.assert_string_in_recent_logs("critical_logs_count")
 
+    def test_free_apps_metrics(self):
+        self.setUpCF(
+            "sample-6.2.0.mda",
+            env_vars={
+                "METRICS_INTERVAL": "10",
+                "PROFILE": "free",
+            },
+        )
+        self.startApp()
+
+        time.sleep(10)
+        self.assert_string_in_recent_logs("MENDIX-METRICS: ")
+        self.assert_string_in_recent_logs("named_users")
+        self.assert_string_in_recent_logs("anonymous_sessions")
+        self.assert_string_in_recent_logs("named_user_sessions")
 
 class TestNewMetricsFlows(basetest.BaseTest):
     def test_fallback_flow_when_server_unreachable(self):


### PR DESCRIPTION
We are starting to push sessions metrics for free apps to influxDB. The following code changes are to support that. 