### PR TITLE
MxBuild process check improvements

### DIFF
--- a/lib/instadeploy.py
+++ b/lib/instadeploy.py
@@ -63,7 +63,7 @@ class InstaDeployThread(threading.Thread):
         self.mx_version = mx_version
 
     def run(self):
-        logger.debug("Going to start mxbuild in serve mode")
+        logger.info("Launching mxbuild in server mode")
         mxbuild.start_mxbuild_server(
             os.path.join(os.getcwd(), ".local"), self.mx_version
         )

--- a/lib/mxbuild.py
+++ b/lib/mxbuild.py
@@ -1,6 +1,8 @@
 import buildpackutil
-import subprocess
+import logger
 import os
+import subprocess
+import time
 
 
 def start_mxbuild_server(dot_local_location, mx_version):
@@ -17,7 +19,7 @@ def start_mxbuild_server(dot_local_location, mx_version):
     jvm_location = buildpackutil.ensure_and_get_jvm(
         mx_version, cache, dot_local_location, package="jdk"
     )
-    subprocess.Popen(
+    process = subprocess.Popen(
         [
             os.path.join(mono_location, "bin/mono"),
             "--config",
@@ -30,3 +32,11 @@ def start_mxbuild_server(dot_local_location, mx_version):
         ],
         env=mono_env,
     )
+    # give mxbuild a few seconds to init, then check if we are still running
+    time.sleep(5)
+    poll = process.poll()
+    if poll is not None:
+        raise Exception(
+            "MxBuild did not start and returned code %d".format(poll)
+        )
+    logger.info("MxBuild is running and warming up")

--- a/lib/mxbuild.py
+++ b/lib/mxbuild.py
@@ -1,8 +1,8 @@
 import buildpackutil
-import logger
 import os
 import subprocess
 import time
+from m2ee import logger
 
 
 def start_mxbuild_server(dot_local_location, mx_version):

--- a/tests/usecase/test_fastdeploy.py
+++ b/tests/usecase/test_fastdeploy.py
@@ -1,6 +1,5 @@
 import basetest
 import requests
-import time
 
 
 class TestCaseFastdeploy(basetest.BaseTest):
@@ -16,6 +15,8 @@ class TestCaseFastdeploy(basetest.BaseTest):
         self.startApp()
 
     def test_fast_deploy(self):
+        self.wait_for_mxbuild()
+
         self.cmd(
             (
                 "wget",
@@ -24,20 +25,8 @@ class TestCaseFastdeploy(basetest.BaseTest):
                 "/mx-buildpack-ci/ci-buildpack-test-app-mx7-18-3.mpk",
             )
         )
+
         full_uri = "https://" + self.app_name + "/_mxbuild/"
-
-        max = 12
-        for attempt in range(0, max):
-            time.sleep(10)
-            r = requests.get(full_uri, auth=("deploy", self.mx_password))
-            if r.status_code == 501:
-                break
-            if attempt == max - 1:
-                raise Exception("Starting MxBuild takes too long")
-
-        # making sure mxbuild is ready
-        time.sleep(10)
-
         r = requests.post(
             full_uri,
             auth=("deploy", self.mx_password),

--- a/tests/usecase/test_java_crash_restarts_process.py
+++ b/tests/usecase/test_java_crash_restarts_process.py
@@ -10,6 +10,7 @@ class TestCaseJavaCrashRestartsProcess(basetest.BaseTest):
             env_vars={
                 "DEPLOY_PASSWORD": self.mx_password,
                 "METRICS_INTERVAL": "10",
+                "BUILDPACK_XTRACE": "false",
             },
         )
         self.startApp()

--- a/tests/usecase/test_jdk_versions.py
+++ b/tests/usecase/test_jdk_versions.py
@@ -96,6 +96,7 @@ class TestJDKVersions(basetest.BaseTest):
             env_vars={"DEPLOY_PASSWORD": self.mx_password},
         )
         self.startApp()
+        self.wait_for_mxbuild()
 
         self.cmd(
             (


### PR DESCRIPTION
During running unit tests for check_db_config_options a test with MxBuild failed twice. To investigate and improve this branch is created. 

Run tests with debug mode enabled. 
Have JDK tests with source push wait for mxbuild, moved wait code to test base class.
Check process status for MxBuild after start.