### PR TITLE
Don't print debugger password in default logging

### DIFF
--- a/start.py
+++ b/start.py
@@ -1096,7 +1096,9 @@ def configure_debugger(m2ee):
             "The remote debugger is now enabled with the value from "
             "environment variable DEBUGGER_PASSWORD."
         )
-        logger.debug("The password to use is %s" % debugger_password)
+        logger.debug(
+            "The password to use is {}".format(debugger_password)
+        )
         logger.info(
             "You can use the remote debugger option in the Mendix "
             "Business Modeler to connect to the /debugger/ sub "

--- a/start.py
+++ b/start.py
@@ -1093,9 +1093,10 @@ def configure_debugger(m2ee):
     response.display_error()
     if not response.has_error():
         logger.info(
-            "The remote debugger is now enabled, the password to "
-            "use is %s" % debugger_password
+            "The remote debugger is now enabled as set with "
+            "environment variable DEBUGGER_PASSWORD."
         )
+        logger.debug("The password to use is %s" % debugger_password)
         logger.info(
             "You can use the remote debugger option in the Mendix "
             "Business Modeler to connect to the /debugger/ sub "

--- a/start.py
+++ b/start.py
@@ -1093,7 +1093,7 @@ def configure_debugger(m2ee):
     response.display_error()
     if not response.has_error():
         logger.info(
-            "The remote debugger is now enabled as set with "
+            "The remote debugger is now enabled with the value from "
             "environment variable DEBUGGER_PASSWORD."
         )
         logger.debug("The password to use is %s" % debugger_password)


### PR DESCRIPTION
Solves request issue #269

Merging to maintenance_update_3.6 to collect a few small changes.