### PR TITLE
Update Java version documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,20 @@ The Java heap size is configured automatically based on best practices. You can 
 
 ### Configuring the Java version
 
-The default Java version is 8 for Mendix 5.18 and higher. If you want to force Java 7 or 8, you can set the environment variable `JAVA_VERSION` to `7` or `8`.
+The build pack will automatically determine the Java version to use based on the runtime version of the app being deployed. The default Java version is 8 for Mendix 5.18 and higher. For Mendix 8 and above the default Java version is 11. In most cases it is not needed to change the Java version determined by the build pack.
+
+*Note*: Starting from Mendix 7.23.1 we changed to use AdoptOpenJDK. The buildpack will automatically determine the vendor based on the Mendix version. The `JAVA_VERSION` variable can be used to select a version number only, not the vendor.
+
+**For Mendix 5** the major java version can be changed by setting `JAVA_VERSION`.  
+For all other versions **the major version number should be respected** and the `JAVA_VERSION` can be used to switch to a different patch version. 
+
+If you want to force Java 7 or 8, you can set the environment variable `JAVA_VERSION` to `7` or `8`:
 
     cf set-env <YOUR_APP> JAVA_VERSION 8
+    
+Or to switch patch version for Java 11:
+
+	cf set-env <YOUR_APP> JAVA_VERSION 11.0.3
 
 
 ### Configuring Custom Runtime Settings


### PR DESCRIPTION
Extend the description of Java versions used by Mendix versions and
what are possible changes an user can make. Also included notice of
Java 11.

Merging to maintenance_update_3.6 to collect a few small changes.