### PR TITLE
Maintenance release 3.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,20 @@ The Java heap size is configured automatically based on best practices. You can 
 
 ### Configuring the Java version
 
-The default Java version is 8 for Mendix 5.18 and higher. If you want to force Java 7 or 8, you can set the environment variable `JAVA_VERSION` to `7` or `8`.
+The build pack will automatically determine the Java version to use based on the runtime version of the app being deployed. The default Java version is 8 for Mendix 5.18 and higher. For Mendix 8 and above the default Java version is 11. In most cases it is not needed to change the Java version determined by the build pack.
+
+*Note*: Starting from Mendix 7.23.1 we changed to use AdoptOpenJDK. The buildpack will automatically determine the vendor based on the Mendix version. The `JAVA_VERSION` variable can be used to select a version number only, not the vendor.
+
+**For Mendix 5** the major java version can be changed by setting `JAVA_VERSION`.  
+For all other versions **the major version number should be respected** and the `JAVA_VERSION` can be used to switch to a different patch version. 
+
+If you want to force Java 7 or 8, you can set the environment variable `JAVA_VERSION` to `7` or `8`:
 
     cf set-env <YOUR_APP> JAVA_VERSION 8
+    
+Or to switch patch version for Java 11:
+
+	cf set-env <YOUR_APP> JAVA_VERSION 11.0.3
 
 
 ### Configuring Custom Runtime Settings

--- a/lib/database_config.py
+++ b/lib/database_config.py
@@ -4,7 +4,7 @@ import os
 import re
 import buildpackutil
 from abc import abstractmethod, ABC
-from urllib.parse import parse_qs, urlencode
+from urllib.parse import parse_qs, urlencode, unquote
 from m2ee import logger  # noqa: E402
 
 
@@ -139,8 +139,8 @@ class DatabaseConfiguration(ABC):
         m2ee_config = {
             "DatabaseType": self.get_database_type(),
             "DatabaseHost": self.get_database_host(),
-            "DatabaseUserName": self.get_database_username(),
-            "DatabasePassword": self.get_database_password(),
+            "DatabaseUserName": unquote(self.get_database_username()),
+            "DatabasePassword": unquote(self.get_database_password()),
             "DatabaseName": self.get_database_name(),
             "DatabaseJdbcUrl": self.get_database_jdbc_url(),
         }

--- a/start.py
+++ b/start.py
@@ -1093,8 +1093,11 @@ def configure_debugger(m2ee):
     response.display_error()
     if not response.has_error():
         logger.info(
-            "The remote debugger is now enabled, the password to "
-            "use is %s" % debugger_password
+            "The remote debugger is now enabled with the value from "
+            "environment variable DEBUGGER_PASSWORD."
+        )
+        logger.debug(
+            "The password to use is {}".format(debugger_password)
         )
         logger.info(
             "You can use the remote debugger option in the Mendix "

--- a/start.py
+++ b/start.py
@@ -29,7 +29,7 @@ from m2ee import M2EE, logger  # noqa: E402
 from nginx import get_path_config, gen_htpasswd  # noqa: E402
 from buildpackutil import i_am_primary_instance  # noqa: E402
 
-BUILDPACK_VERSION = "3.6.0"
+BUILDPACK_VERSION = "3.6.1"
 
 
 logger.setLevel(buildpackutil.get_buildpack_loglevel())

--- a/start.py
+++ b/start.py
@@ -1096,9 +1096,7 @@ def configure_debugger(m2ee):
             "The remote debugger is now enabled with the value from "
             "environment variable DEBUGGER_PASSWORD."
         )
-        logger.debug(
-            "The password to use is {}".format(debugger_password)
-        )
+        logger.debug("The password to use is {}".format(debugger_password))
         logger.info(
             "You can use the remote debugger option in the Mendix "
             "Business Modeler to connect to the /debugger/ sub "

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,6 +15,9 @@ export CF_DOMAIN="cf-test.example.com"
 export MX_PASSWORD="sebaiNgooyiyoh9cheuquueghoongo@!"
 ```
 
+
+## Selecting the build pack repo and branch
+
 By default the test asumes you pushed your changes to a public git repository. The definitive
 url is based on the branch you are using. The following can be done to change the default
 location of the build pack:
@@ -27,6 +30,14 @@ build pack uploaded to the Cloud Foundry cluster. This can be used if you want t
 you changes but don't want to make it public yet.
 
 
+## Simultanious runs
+
+All tests applications deployed have a prefix so that the test script can clean up before and after any applications that are left behind. This however limits the number or runs into the same org and space to one (1).   
+To overcome this you can specify `TEST_PREFIX` as environment variable to change  the naming of the test apps. `TEST_PREFIX` defaults to `ops`. 
+
+
+## Running tests
+
 To run all the tests locally you need to do is to go to the root folder.
 
 ```
@@ -34,3 +45,4 @@ make test
 ```
 
 To run a singe test take look at `run.sh`, e.g. you need to PYTHONPATH.
+

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -13,9 +13,11 @@ fi
 cf login -a "$CF_ENDPOINT" -u "$CF_USER" -p "$CF_PASSWORD" -o "$CF_ORG" -s "$CF_SPACE" > /dev/null
 
 function cleanup {
+    PREFIX=`echo ${TEST_PREFIX:-ops} | sed -e 's/-$//'`
+
     echo "begin clean up of environment"
-    cf apps 2>&1 | grep ops- | awk '{print $1}' | xargs -n 1 -P 5 --no-run-if-empty cf delete -r -f | grep -v 'OK' || true
-    cf s 2>&1 | grep ops- | awk '{print $1}' | xargs -n 1 -P 5 --no-run-if-empty cf ds -f $service | grep -v 'OK' || true
+    cf apps 2>&1 | grep "${PREFIX}-" | awk '{print $1}' | xargs -n 1 -P 5 --no-run-if-empty cf delete -r -f | grep -v 'OK' || true
+    cf s 2>&1 | grep "${PREFIX}-" | awk '{print $1}' | xargs -n 1 -P 5 --no-run-if-empty cf ds -f $service | grep -v 'OK' || true
     cf delete-orphaned-routes -f 2>&1 | grep -i deleting || true
     echo "completed environment clean up"
 }

--- a/tests/usecase/basetest.py
+++ b/tests/usecase/basetest.py
@@ -45,8 +45,10 @@ class BaseTest(unittest.TestCase):
         )
         self.mx_password = os.environ.get("MX_PASSWORD", "Y0l0lop13#123")
         self.app_id = str(uuid.uuid4()).split("-")[0]
-        self.subdomain = "ops-" + self.app_id
-        self.app_name = "%s.%s" % (self.subdomain, self.cf_domain)
+
+        self.app_prefix = os.environ.get("TEST_PREFIX", "ops-")
+        self.subdomain = "{}-{}".format(self.app_prefix, self.app_id)
+        self.app_name = "{}.{}".format(self.subdomain, self.cf_domain)
 
     def setUp(self):
         self.cf_home = tempfile.TemporaryDirectory()

--- a/tests/usecase/test_db_rds.py
+++ b/tests/usecase/test_db_rds.py
@@ -80,7 +80,6 @@ class TestCaseRdsDryRun:
         assert config["DatabaseName"] == "dbuajsdhkasdhaks"
         assert config["DatabaseJdbcUrl"].find("tcpKeepAlive") >= 0
 
-
     def test_rds_testfree_postgres_urlencoded(self):
         os.environ["VCAP_SERVICES"] = self.urlencoded_rds_vcap_example
 

--- a/tests/usecase/test_db_rds.py
+++ b/tests/usecase/test_db_rds.py
@@ -6,7 +6,7 @@ from database_config import DatabaseConfigurationFactory
 # export PYTHONPATH=<buildpack-root>/lib
 
 
-class TestCaseSapHanaDryRun:
+class TestCaseRdsDryRun:
 
     rds_vcap_example = """
 {
@@ -19,6 +19,35 @@ class TestCaseSapHanaDryRun:
      "password": "na8nanlayaona0--anbs",
      "uri": "postgres://ua98s7ananla:na8nanlayaona0--anbs@rdsbroker-testfree-nonprod-1-eu-west-1.asdbjasdg.eu-west-1.rds.amazonaws.com:5432/dbuajsdhkasdhaks",
      "username": "ua98s7ananla"
+    },
+    "instance_name": "ops-432a659e.test.foo.io-database",
+    "label": "rds-testfree",
+    "name": "ops-432a659e.test.foo.io-database",
+    "plan": "shared-psql-testfree",
+    "provider": null,
+    "syslog_drain_url": null,
+    "tags": [
+     "database",
+     "RDS",
+     "postgresql"
+    ],
+    "volume_mounts": []
+   }
+  ]
+}
+    """  # noqa
+
+    urlencoded_rds_vcap_example = """
+{
+ "rds-testfree": [
+   {
+    "binding_name": null,
+    "credentials": {
+     "db_name": "dbuajsdhkasdhaks",
+     "host": "rdsbroker-testfree-nonprod-1-eu-west-1.asdbjasdg.eu-west-1.rds.amazonaws.com",
+     "password": "na8na%2Bnlay%26aona0--anbs",
+     "uri": "postgres://ua98s7%3Fananla:na8na%2Bnlay%26aona0--anbs@rdsbroker-testfree-nonprod-1-eu-west-1.asdbjasdg.eu-west-1.rds.amazonaws.com:5432/dbuajsdhkasdhaks",
+     "username": "ua98s7%3Fananla"
     },
     "instance_name": "ops-432a659e.test.foo.io-database",
     "label": "rds-testfree",
@@ -50,3 +79,20 @@ class TestCaseSapHanaDryRun:
         )
         assert config["DatabaseName"] == "dbuajsdhkasdhaks"
         assert config["DatabaseJdbcUrl"].find("tcpKeepAlive") >= 0
+
+
+    def test_rds_testfree_postgres_urlencoded(self):
+        os.environ["VCAP_SERVICES"] = self.urlencoded_rds_vcap_example
+
+        factory = DatabaseConfigurationFactory()
+
+        config = factory.get_instance().get_m2ee_configuration()
+        assert config["DatabaseType"] == "PostgreSQL"
+        assert (
+            config["DatabaseHost"]
+            == "rdsbroker-testfree-nonprod-1-eu-west-1.asdbjasdg.eu-west-1.rds.amazonaws.com:5432"  # noqa: E501
+        )
+        assert config["DatabaseName"] == "dbuajsdhkasdhaks"
+        assert config["DatabaseJdbcUrl"].find("tcpKeepAlive") >= 0
+        assert config["DatabaseUserName"] == "ua98s7?ananla"
+        assert config["DatabasePassword"] == "na8na+nlay&aona0--anbs"


### PR DESCRIPTION
Maintenance release with the following improvements

* #273 - Don't print debugger password in default logging
* #274 - Update Java version documentation
* #275 - For local test run, add option to change app name prefix
* #276 - URLDecode username and password from db credentials