### PR TITLE
Passing Agent Config is moved to environment variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,13 +323,14 @@ Please note that AppDynamics requires Mendix 6.2 or higher.
 
 To enable Datadog, configure the following environment variables:
 
-    DD_API_KEY
-    DD_LOG_LEVEL
+|            |         |
+| ----------- | -------- |
+| DD\_API_KEY | The `DD_API_KEY` environment variable should refer to the Datadog API key that can be configured in the Integrations -> API screen of the Datadog user interface. |
+| DD\_LOG_LEVEL | The `DD_LOG_LEVEL` environment ensures that messages are sent to Datadog. A safe level would be `INFO`, but it can be later adjusted to different levels: `CRITICAL`, `ERROR`, `WARNING`, or `DEBUG`. |
 
-* The `DD_API_KEY` environment variable should refer to the Datadog API key that can be configured in the Integrations -> API screen of the Datadog user interface.
-* The `DD_LOG_LEVEL` environment ensures that messages are sent to Datadog. A safe level would be `INFO`, but it can be later adjusted to different levels: `CRITICAL`, `ERROR`, `WARNING`, or `DEBUG`.
+To receive metrics from the runtime, the Mendix Agent is added to the runtime as Java agent. This agent can be configured by passing a JSON in the environment variable `METRICS_AGENT_CONFIG` as described in [Datadog for v4 Mendix Cloud](https://docs.mendix.com/developerportal/operate/datadog-metrics). 
 
-Please note that Datadog integration requires Mendix 7.14 or higher. If an older version is used, then a warning will be displayed in the logs and the Datadog integration will not be enabled.
+Please note that Datadog integration **requires Mendix 7.14 or higher**. If an older version is used, then a warning will be displayed in the logs and the Datadog integration will not be enabled.
 
 Data Snapshots
 ====

--- a/start.py
+++ b/start.py
@@ -29,7 +29,7 @@ from m2ee import M2EE, logger  # noqa: E402
 from nginx import get_path_config, gen_htpasswd  # noqa: E402
 from buildpackutil import i_am_primary_instance  # noqa: E402
 
-BUILDPACK_VERSION = "3.7.1"
+BUILDPACK_VERSION = "3.7.2"
 
 
 logger.setLevel(buildpackutil.get_buildpack_loglevel())


### PR DESCRIPTION
Passing configuration for the Mendix Agent by using Custom Runtime
Settings is deprecated and is moved to METRICS_AGENT_CONFIG as
environment variable.