### PR TITLE
Removing Mendix 5 support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,17 +133,14 @@ The Java heap size is configured automatically based on best practices. You can 
 
 ### Configuring the Java version
 
-The build pack will automatically determine the Java version to use based on the runtime version of the app being deployed. The default Java version is 8 for Mendix 5.18 and higher. For Mendix 8 and above the default Java version is 11. In most cases it is not needed to change the Java version determined by the build pack.
+The build pack will automatically determine the Java version to use based on the runtime version of the app being deployed. The default Java version is 8 for Mendix 6 and higher. For Mendix 8 and above the default Java version is 11. In most cases it is not needed to change the Java version determined by the build pack.
 
 *Note*: Starting from Mendix 7.23.1 we changed to use AdoptOpenJDK. The buildpack will automatically determine the vendor based on the Mendix version. The `JAVA_VERSION` variable can be used to select a version number only, not the vendor.
-
-**For Mendix 5** the major java version can be changed by setting `JAVA_VERSION`.  
-For all other versions **the major version number should be respected** and the `JAVA_VERSION` can be used to switch to a different patch version. 
 
 If you want to force Java 7 or 8, you can set the environment variable `JAVA_VERSION` to `7` or `8`:
 
     cf set-env <YOUR_APP> JAVA_VERSION 8
-    
+
 Or to switch patch version for Java 11:
 
 	cf set-env <YOUR_APP> JAVA_VERSION 11.0.3
@@ -177,7 +174,7 @@ to configure multiple supported headers, you can set it like below:
 
 ### Horizontal Scaling
 
-There are two ways for horizontal scaling in Mendix. In Mendix 5.15+ you can use sticky sessions. Mendix 7 brings this even further by no longer requiring a state store. See below on how to activate these settings, based on the Mendix version you use.
+There are two ways for horizontal scaling in Mendix. In Mendix 6 you can use sticky sessions. Mendix 7 brings this even further by no longer requiring a state store. See below on how to activate these settings, based on the Mendix version you use.
 
 #### Things to keep in mind when scaling horizontally
 
@@ -189,7 +186,7 @@ In all horizontal scaling scenarios, extra care needs to be taken when programmi
 * relying on singleton variables to keep global application state
 * relying on scheduled events to make changes in memory, scheduled events will only run on the primary instance
 
-#### Enabling Sticky Sessions (Mendix 5.15+)
+#### Enabling Sticky Sessions (Mendix 6)
 
 If you want to enable sticky sessions, the only change that is needed is to set the environment variable `ENABLE_STICKY_SESSIONS` to `true`. This will replace the Mendix session cookie name from `XASSESSIONID` to `JSESSIONID` which will trigger sticky session detection in the Cloud Foundry http router. Watch out: custom login code might break if it still injects the `XASSESSIONID` cookie.
 
@@ -328,7 +325,7 @@ To enable Datadog, configure the following environment variables:
 | DD\_API_KEY | The `DD_API_KEY` environment variable should refer to the Datadog API key that can be configured in the Integrations -> API screen of the Datadog user interface. |
 | DD\_LOG_LEVEL | The `DD_LOG_LEVEL` environment ensures that messages are sent to Datadog. A safe level would be `INFO`, but it can be later adjusted to different levels: `CRITICAL`, `ERROR`, `WARNING`, or `DEBUG`. |
 
-To receive metrics from the runtime, the Mendix Agent is added to the runtime as Java agent. This agent can be configured by passing a JSON in the environment variable `METRICS_AGENT_CONFIG` as described in [Datadog for v4 Mendix Cloud](https://docs.mendix.com/developerportal/operate/datadog-metrics). 
+To receive metrics from the runtime, the Mendix Agent is added to the runtime as Java agent. This agent can be configured by passing a JSON in the environment variable `METRICS_AGENT_CONFIG` as described in [Datadog for v4 Mendix Cloud](https://docs.mendix.com/developerportal/operate/datadog-metrics).
 
 Please note that Datadog integration **requires Mendix 7.14 or higher**. If an older version is used, then a warning will be displayed in the logs and the Datadog integration will not be enabled.
 

--- a/bin/compile.py
+++ b/bin/compile.py
@@ -135,6 +135,12 @@ def preflight_check():
     if not check_database_environment_variable():
         raise Exception("Missing environment variables")
 
+    mx_version_str = get_runtime_version()
+    logging.info("Preflight check on version {}".format(mx_version_str))
+    mx_version = MXVersion(str(mx_version_str))
+    if not buildpackutil.check_deprecation(mx_version):
+        raise Exception("Version {} is deprecated.".format(mx_version_str))
+
 
 def set_up_directory_structure():
     logging.debug("making directory structure")

--- a/lib/buildpackutil.py
+++ b/lib/buildpackutil.py
@@ -14,6 +14,15 @@ import requests  # noqa: E402
 from m2ee.version import MXVersion  # noqa: E402
 
 
+def check_deprecation(version):
+    if version >= MXVersion("5.0.0") and version < MXVersion("6.0.0"):
+        logging.error("Mendix Runtime 5.x is no longer supported.")
+        logging.error("You can version pin on v3.8.0.")
+        return False
+
+    return True
+
+
 def get_vcap_services_data():
     if os.environ.get("VCAP_SERVICES"):
         return json.loads(os.environ.get("VCAP_SERVICES"))
@@ -176,7 +185,7 @@ def get_java_version(mx_version):
             "version": os.getenv("JAVA_VERSION", "8u202"),
             "vendor": "oracle",
         }
-    elif mx_version >= MXVersion("5.18"):
+    elif mx_version >= MXVersion("6.0"):
         java_version = {
             "version": os.getenv("JAVA_VERSION", "8u51"),
             "vendor": "oracle",

--- a/start.py
+++ b/start.py
@@ -29,7 +29,7 @@ from m2ee import M2EE, logger  # noqa: E402
 from nginx import get_path_config, gen_htpasswd  # noqa: E402
 from buildpackutil import i_am_primary_instance  # noqa: E402
 
-BUILDPACK_VERSION = "3.8.0"
+BUILDPACK_VERSION = "4.0.0"
 
 
 logger.setLevel(buildpackutil.get_buildpack_loglevel())
@@ -449,7 +449,7 @@ def _get_s3_specific_config(vcap_services, m2ee):
         config["com.mendix.storage.s3.UseV2Auth"] = v2_auth
     if endpoint:
         config["com.mendix.storage.s3.EndPoint"] = endpoint
-    if m2ee.config.get_runtime_version() >= 5.17 and encryption_keys:
+    if m2ee.config.get_runtime_version() >= 6 and encryption_keys:
         config["com.mendix.storage.s3.EncryptionKeys"] = encryption_keys
     if m2ee.config.get_runtime_version() >= 6 and sse:
         config["com.mendix.storage.s3.UseSSE"] = sse
@@ -659,7 +659,7 @@ def set_runtime_config(metadata, mxruntime_config, vcap_data, m2ee):
     if m2ee.config.get_runtime_version() >= 7 and not i_am_primary_instance():
         app_config["com.mendix.core.isClusterSlave"] = "true"
     elif (
-        m2ee.config.get_runtime_version() >= 5.15
+        m2ee.config.get_runtime_version() >= 6
         and os.getenv("ENABLE_STICKY_SESSIONS", "false").lower() == "true"
     ):
         logger.info("Enabling sticky sessions")
@@ -1135,7 +1135,7 @@ def display_java_version():
 
 
 def display_running_version(m2ee):
-    if m2ee.config.get_runtime_version() >= 4.4:
+    if m2ee.config.get_runtime_version() >= 6.0:
         feedback = m2ee.client.about().get_feedback()
         if "model_version" in feedback:
             logger.info("Model version: %s" % feedback["model_version"])

--- a/tests/usecase/test_deprecations.py
+++ b/tests/usecase/test_deprecations.py
@@ -1,0 +1,37 @@
+import basetest
+
+
+class TestCaseDeprecationMx5MPK(basetest.BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.setUpCF(
+            "mx5.3.2_app.mpk",
+            env_vars={
+                "DEPLOY_PASSWORD": self.mx_password,
+                "DEVELOPMENT_MODE": True,
+            },
+        )
+
+    def test_mx5_mpk(self):
+        self.startApp(expect_failure=True)
+        self.assert_string_in_recent_logs(
+            "Mendix Runtime 5.x is no longer supported"
+        )
+
+
+class TestCaseDeprecationMx5MDA(basetest.BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.setUpCF(
+            "mx5.3.2_app.mda",
+            env_vars={
+                "DEPLOY_PASSWORD": self.mx_password,
+                "DEVELOPMENT_MODE": True,
+            },
+        )
+
+    def test_mx5_mda(self):
+        self.startApp(expect_failure=True)
+        self.assert_string_in_recent_logs(
+            "Mendix Runtime 5.x is no longer supported"
+        )


### PR DESCRIPTION
Please version pin on build pack v3.8 if you need Mx5 to run.