### PR TITLE
[DEP-1417] Added ClientCertificateUsages for runtimes >= 7.20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,13 @@ before_install:
   - sudo curl -s https://download.mendix.com/Mendix-CA-G2.crt -o /usr/local/share/ca-certificates/ca.crt && sudo update-ca-certificates
 
 install:
+  - |
+    ( set -euo pipefail
+      if [[ "${TRAVIS_COMMIT}" != "$(git rev-parse HEAD)" ]]; then
+        echo "Commit $(git rev-parse HEAD) doesn't match expected commit ${TRAVIS_COMMIT}"
+        git checkout "${TRAVIS_COMMIT}"
+      fi
+    )
   - pip3 install -r tests/requirements.txt
 
 before_script:

--- a/lib/datadog.py
+++ b/lib/datadog.py
@@ -39,12 +39,11 @@ def _get_service():
 
 
 def _get_application():
-    return (
-        list(filter(lambda x: "app:" in x, buildpackutil.get_tags()))[0].split(
-            ":"
-        )[1]
-        or buildpackutil.get_appname()
-    )
+    app_tags = list(filter(lambda x: "app:" in x, buildpackutil.get_tags()))
+    if app_tags:
+        return app_tags[0].split(":")[1]
+    else:
+        return buildpackutil.get_appname()
 
 
 def _get_statsd_port():

--- a/start.py
+++ b/start.py
@@ -29,7 +29,7 @@ from m2ee import M2EE, logger  # noqa: E402
 from nginx import get_path_config, gen_htpasswd  # noqa: E402
 from buildpackutil import i_am_primary_instance  # noqa: E402
 
-BUILDPACK_VERSION = "4.1.1"
+BUILDPACK_VERSION = "4.1.2"
 
 
 logger.setLevel(buildpackutil.get_buildpack_loglevel())
@@ -575,7 +575,11 @@ def get_client_certificates():
     if len(files) > 0:
         config["ClientCertificates"] = ",".join(files)
         config["ClientCertificatePasswords"] = ",".join(passwords)
-        config["WebServiceClientCertificates"] = pins
+        if m2ee.config.get_runtime_version() < 7.20:
+            # Deprecated in 7.20
+            config["WebServiceClientCertificates"] = pins
+        else:
+            config["ClientCertificateUsages"] = pins
     return config
 
 


### PR DESCRIPTION
As per the [Mendix 7.20 release notes](https://docs.mendix.com/releasenotes/studio-pro/7.2), `WebServiceClientCertificates` has been deprecated in favour of `ClientCertificateUsages`.

This is a cosmetic change only and the data structure for this configuration option has not changed.