### PR TITLE
[CLDOPS-6596] Added exponential backoff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ test:
 	nosetests --verbosity=3 --processes=10 --process-timeout=3600 --with-timer --timer-no-color tests/usecase/test_*.py
 
 lint:
-	flake8 --exclude .git,__pycache__,lib/certifi,lib/idna,lib/psycopg2,lib/urllib3,lib/chardet,lib/httplib2,lib/requests,lib/yaml
+	flake8 --exclude .git,__pycache__,lib/backoff,lib/certifi,lib/idna,lib/psycopg2,lib/urllib3,lib/chardet,lib/httplib2,lib/requests,lib/yaml
 	black --target-version py34 --check --diff .
 
 install:

--- a/README.md
+++ b/README.md
@@ -289,7 +289,14 @@ To receive metrics from the runtime, the Mendix Java Agent is added to the runti
 
 Please note that Datadog integration **requires Mendix 7.14 or higher**. If an older version is used, then a warning will be displayed in the logs and the Datadog integration will not be enabled.
 
-The Datadog integration features a full Datadog Agent installation inspired by the [official Datadog Cloud Foundry Buildpack](https://github.com/DataDog/datadog-cloudfoundry-buildpack). Specific agent checks are enabled and configured specifically for Mendix applications. Additionally, we configure the following Datadog environment variables for you:
+The Datadog integration features a full Datadog Agent installation inspired by the [official Datadog Cloud Foundry Buildpack](https://github.com/DataDog/datadog-cloudfoundry-buildpack). Specific agent checks are enabled and configured specifically for Mendix applications.
+
+#### Presets
+For correlation purposes, we set the Datadog `service` for you to match your **application name**. This name is derived in the following order:
+1. Your Mendix `app:` tag if you have set this in the runtime settings.<br/>*Example:* for `app:myfirstapp`, `service` will be set to `myfirstapp`.
+2. The first part of the Cloud Foundry route URI configured for your application, without numeric characters.<br/>*Example:* for a route URI `myfirstapp1000-test.example.com`, `service` will be set to `myfirstapp`.
+
+Additionally, we configure the following Datadog environment variables for you:
 
 | Environment Variable | Value | Can Be Overridden? | Description |
 |-|-|-|-|
@@ -297,8 +304,8 @@ The Datadog integration features a full Datadog Agent installation inspired by t
 | `DD_HOSTNAME` |`<app>-<env>.mendixcloud.com-<instance>` | No | Human-readable host name for your application |
 | `DD_JMXFETCH_ENABLED`| `false`| No | Disables Datadog Java Trace Agent JMX metrics fetching, since this is already handled by the Mendix Runtime. |
 | `DD_LOGS_ENABLED`| `true` | No | Enables sending your application logs directly to Datadog |
-| `DD_SERVICE_MAPPING`| `<database>:<app>:db` | No | Links your database to your app in Datadog APM. Is only set when `DD_TRACE_ENABLED` is set to `true`. |
-| `DD_SERVICE_NAME`| `<app>` | No | Defaults to your application name. Is only set when `DD_TRACE_ENABLED` is set to `true`. |
+| `DD_SERVICE_MAPPING`| `<database>:<app>.db` | No | Links your database to your app in Datadog APM. Is only set when `DD_TRACE_ENABLED` is set to `true`. |
+| `DD_SERVICE_NAME`| `<app>` | No | Defaults to your application name as described before. Is only set when `DD_TRACE_ENABLED` is set to `true`. |
 | `DD_TAGS`| Various Cloud Foundry tags | Yes | If set, your tags will be added to the list of supplied Cloud Foundry tags |
 | `DD_TRACE_ENABLED`| `false` | Yes | Disables Datadog APM by default. **Enabling Datadog APM is experimental and enables the [Datadog Java Trace Agent](https://docs.datadoghq.com/tracing/setup/java/) alongside the Mendix Java Agent.** |
 

--- a/lib-requirements.txt
+++ b/lib-requirements.txt
@@ -1,4 +1,5 @@
-# lists libraries in the build pack lib folder
+# lists libraries in the build pack lib folder, plus imports
+backoff==1.10.0
 certifi==2019.3.9
 chardet==3.0.4
 httplib2==0.10.3

--- a/lib/backoff/__init__.py
+++ b/lib/backoff/__init__.py
@@ -1,0 +1,29 @@
+# coding:utf-8
+"""
+Function decoration for backoff and retry
+
+This module provides function decorators which can be used to wrap a
+function such that it will be retried until some condition is met. It
+is meant to be of use when accessing unreliable resources with the
+potential for intermittent failures i.e. network resources and external
+APIs. Somewhat more generally, it may also be of use for dynamically
+polling resources for externally generated content.
+
+For examples and full documentation see the README at
+https://github.com/litl/backoff
+"""
+from backoff._decorator import on_predicate, on_exception
+from backoff._jitter import full_jitter, random_jitter
+from backoff._wait_gen import constant, expo, fibo
+
+__all__ = [
+    'on_predicate',
+    'on_exception',
+    'constant',
+    'expo',
+    'fibo',
+    'full_jitter',
+    'random_jitter'
+]
+
+__version__ = '1.10.0'

--- a/lib/backoff/_async.py
+++ b/lib/backoff/_async.py
@@ -1,0 +1,166 @@
+# coding:utf-8
+import datetime
+import functools
+import asyncio  # Python 3.5 code and syntax is allowed in this file
+from datetime import timedelta
+
+from backoff._common import (_init_wait_gen, _maybe_call, _next_wait)
+
+
+def _ensure_coroutine(coro_or_func):
+    if asyncio.iscoroutinefunction(coro_or_func):
+        return coro_or_func
+    else:
+        @functools.wraps(coro_or_func)
+        async def f(*args, **kwargs):
+            return coro_or_func(*args, **kwargs)
+        return f
+
+
+def _ensure_coroutines(coros_or_funcs):
+    return [_ensure_coroutine(f) for f in coros_or_funcs]
+
+
+async def _call_handlers(hdlrs, target, args, kwargs, tries, elapsed, **extra):
+    details = {
+        'target': target,
+        'args': args,
+        'kwargs': kwargs,
+        'tries': tries,
+        'elapsed': elapsed,
+    }
+    details.update(extra)
+    for hdlr in hdlrs:
+        await hdlr(details)
+
+
+def retry_predicate(target, wait_gen, predicate,
+                    max_tries, max_time, jitter,
+                    on_success, on_backoff, on_giveup,
+                    wait_gen_kwargs):
+    on_success = _ensure_coroutines(on_success)
+    on_backoff = _ensure_coroutines(on_backoff)
+    on_giveup = _ensure_coroutines(on_giveup)
+
+    # Easy to implement, please report if you need this.
+    assert not asyncio.iscoroutinefunction(max_tries)
+    assert not asyncio.iscoroutinefunction(jitter)
+
+    assert asyncio.iscoroutinefunction(target)
+
+    @functools.wraps(target)
+    async def retry(*args, **kwargs):
+
+        # change names because python 2.x doesn't have nonlocal
+        max_tries_ = _maybe_call(max_tries)
+        max_time_ = _maybe_call(max_time)
+
+        tries = 0
+        start = datetime.datetime.now()
+        wait = _init_wait_gen(wait_gen, wait_gen_kwargs)
+        while True:
+            tries += 1
+            elapsed = timedelta.total_seconds(datetime.datetime.now() - start)
+            details = (target, args, kwargs, tries, elapsed)
+
+            ret = await target(*args, **kwargs)
+            if predicate(ret):
+                max_tries_exceeded = (tries == max_tries_)
+                max_time_exceeded = (max_time_ is not None and
+                                     elapsed >= max_time_)
+
+                if max_tries_exceeded or max_time_exceeded:
+                    await _call_handlers(on_giveup, *details, value=ret)
+                    break
+
+                try:
+                    seconds = _next_wait(wait, jitter, elapsed, max_time_)
+                except StopIteration:
+                    await _call_handlers(on_giveup, *details, value=ret)
+                    break
+
+                await _call_handlers(on_backoff, *details, value=ret,
+                                     wait=seconds)
+
+                # Note: there is no convenient way to pass explicit event
+                # loop to decorator, so here we assume that either default
+                # thread event loop is set and correct (it mostly is
+                # by default), or Python >= 3.5.3 or Python >= 3.6 is used
+                # where loop.get_event_loop() in coroutine guaranteed to
+                # return correct value.
+                # See for details:
+                #   <https://groups.google.com/forum/#!topic/python-tulip/yF9C-rFpiKk>
+                #   <https://bugs.python.org/issue28613>
+                await asyncio.sleep(seconds)
+                continue
+            else:
+                await _call_handlers(on_success, *details, value=ret)
+                break
+
+        return ret
+
+    return retry
+
+
+def retry_exception(target, wait_gen, exception,
+                    max_tries, max_time, jitter, giveup,
+                    on_success, on_backoff, on_giveup,
+                    wait_gen_kwargs):
+    on_success = _ensure_coroutines(on_success)
+    on_backoff = _ensure_coroutines(on_backoff)
+    on_giveup = _ensure_coroutines(on_giveup)
+    giveup = _ensure_coroutine(giveup)
+
+    # Easy to implement, please report if you need this.
+    assert not asyncio.iscoroutinefunction(max_tries)
+    assert not asyncio.iscoroutinefunction(jitter)
+
+    @functools.wraps(target)
+    async def retry(*args, **kwargs):
+        # change names because python 2.x doesn't have nonlocal
+        max_tries_ = _maybe_call(max_tries)
+        max_time_ = _maybe_call(max_time)
+
+        tries = 0
+        start = datetime.datetime.now()
+        wait = _init_wait_gen(wait_gen, wait_gen_kwargs)
+        while True:
+            tries += 1
+            elapsed = timedelta.total_seconds(datetime.datetime.now() - start)
+            details = (target, args, kwargs, tries, elapsed)
+
+            try:
+                ret = await target(*args, **kwargs)
+            except exception as e:
+                giveup_result = await giveup(e)
+                max_tries_exceeded = (tries == max_tries_)
+                max_time_exceeded = (max_time_ is not None and
+                                     elapsed >= max_time_)
+
+                if giveup_result or max_tries_exceeded or max_time_exceeded:
+                    await _call_handlers(on_giveup, *details)
+                    raise
+
+                try:
+                    seconds = _next_wait(wait, jitter, elapsed, max_time_)
+                except StopIteration:
+                    await _call_handlers(on_giveup, *details)
+                    raise e
+
+                await _call_handlers(on_backoff, *details, wait=seconds)
+
+                # Note: there is no convenient way to pass explicit event
+                # loop to decorator, so here we assume that either default
+                # thread event loop is set and correct (it mostly is
+                # by default), or Python >= 3.5.3 or Python >= 3.6 is used
+                # where loop.get_event_loop() in coroutine guaranteed to
+                # return correct value.
+                # See for details:
+                #   <https://groups.google.com/forum/#!topic/python-tulip/yF9C-rFpiKk>
+                #   <https://bugs.python.org/issue28613>
+                await asyncio.sleep(seconds)
+            else:
+                await _call_handlers(on_success, *details)
+
+                return ret
+    return retry

--- a/lib/backoff/_common.py
+++ b/lib/backoff/_common.py
@@ -1,0 +1,101 @@
+# coding:utf-8
+
+import functools
+import logging
+import sys
+import traceback
+import warnings
+
+
+# Use module-specific logger with a default null handler.
+_logger = logging.getLogger('backoff')
+_logger.addHandler(logging.NullHandler())  # pragma: no cover
+_logger.setLevel(logging.INFO)
+
+
+# Evaluate arg that can be either a fixed value or a callable.
+def _maybe_call(f, *args, **kwargs):
+    return f(*args, **kwargs) if callable(f) else f
+
+
+def _init_wait_gen(wait_gen, wait_gen_kwargs):
+    kwargs = {k: _maybe_call(v) for k, v in wait_gen_kwargs.items()}
+    return wait_gen(**kwargs)
+
+
+def _next_wait(wait, jitter, elapsed, max_time):
+    value = next(wait)
+    try:
+        if jitter is not None:
+            seconds = jitter(value)
+        else:
+            seconds = value
+    except TypeError:
+        warnings.warn(
+            "Nullary jitter function signature is deprecated. Use "
+            "unary signature accepting a wait value in seconds and "
+            "returning a jittered version of it.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        seconds = value + jitter()
+
+    # don't sleep longer than remaining alloted max_time
+    if max_time is not None:
+        seconds = min(seconds, max_time - elapsed)
+
+    return seconds
+
+
+# Configure handler list with user specified handler and optionally
+# with a default handler bound to the specified logger.
+def _config_handlers(user_handlers, default_handler=None, logger=None):
+    handlers = []
+    if logger is not None:
+        # bind the specified logger to the default log handler
+        log_handler = functools.partial(default_handler, logger=logger)
+        handlers.append(log_handler)
+
+    if user_handlers is None:
+        return handlers
+
+    # user specified handlers can either be an iterable of handlers
+    # or a single handler. either way append them to the list.
+    if hasattr(user_handlers, '__iter__'):
+        # add all handlers in the iterable
+        handlers += list(user_handlers)
+    else:
+        # append a single handler
+        handlers.append(user_handlers)
+
+    return handlers
+
+
+# Default backoff handler
+def _log_backoff(details, logger):
+    msg = "Backing off %s(...) for %.1fs (%s)"
+    log_args = [details['target'].__name__, details['wait']]
+
+    exc_typ, exc, _ = sys.exc_info()
+    if exc is not None:
+        exc_fmt = traceback.format_exception_only(exc_typ, exc)[-1]
+        log_args.append(exc_fmt.rstrip("\n"))
+    else:
+        log_args.append(details['value'])
+    logger.info(msg, *log_args)
+
+
+# Default giveup handler
+def _log_giveup(details, logger):
+    msg = "Giving up %s(...) after %d tries (%s)"
+    log_args = [details['target'].__name__, details['tries']]
+
+    exc_typ, exc, _ = sys.exc_info()
+    if exc is not None:
+        exc_fmt = traceback.format_exception_only(exc_typ, exc)[-1]
+        log_args.append(exc_fmt.rstrip("\n"))
+    else:
+        log_args.append(details['value'])
+
+    logger.error(msg, *log_args)

--- a/lib/backoff/_decorator.py
+++ b/lib/backoff/_decorator.py
@@ -1,0 +1,178 @@
+# coding:utf-8
+from __future__ import unicode_literals
+
+import logging
+import operator
+import sys
+
+from backoff._common import (_config_handlers, _log_backoff, _log_giveup)
+from backoff._jitter import full_jitter
+from backoff import _sync
+
+
+# python 2.7 -> 3.x compatibility for str and unicode
+try:
+    basestring
+except NameError:  # pragma: python=3.5
+    basestring = str
+
+
+def on_predicate(wait_gen,
+                 predicate=operator.not_,
+                 max_tries=None,
+                 max_time=None,
+                 jitter=full_jitter,
+                 on_success=None,
+                 on_backoff=None,
+                 on_giveup=None,
+                 logger='backoff',
+                 **wait_gen_kwargs):
+    """Returns decorator for backoff and retry triggered by predicate.
+
+    Args:
+        wait_gen: A generator yielding successive wait times in
+            seconds.
+        predicate: A function which when called on the return value of
+            the target function will trigger backoff when considered
+            truthily. If not specified, the default behavior is to
+            backoff on falsey return values.
+        max_tries: The maximum number of attempts to make before giving
+            up. In the case of failure, the result of the last attempt
+            will be returned. The default value of None means there
+            is no limit to the number of tries. If a callable is passed,
+            it will be evaluated at runtime and its return value used.
+        max_time: The maximum total amount of time to try for before
+            giving up. If this time expires, the result of the last
+            attempt will be returned. If a callable is passed, it will
+            be evaluated at runtime and its return value used.
+        jitter: A function of the value yielded by wait_gen returning
+            the actual time to wait. This distributes wait times
+            stochastically in order to avoid timing collisions across
+            concurrent clients. Wait times are jittered by default
+            using the full_jitter function. Jittering may be disabled
+            altogether by passing jitter=None.
+        on_success: Callable (or iterable of callables) with a unary
+            signature to be called in the event of success. The
+            parameter is a dict containing details about the invocation.
+        on_backoff: Callable (or iterable of callables) with a unary
+            signature to be called in the event of a backoff. The
+            parameter is a dict containing details about the invocation.
+        on_giveup: Callable (or iterable of callables) with a unary
+            signature to be called in the event that max_tries
+            is exceeded.  The parameter is a dict containing details
+            about the invocation.
+        logger: Name of logger or Logger object to log to. Defaults to
+            'backoff'.
+        **wait_gen_kwargs: Any additional keyword args specified will be
+            passed to wait_gen when it is initialized.  Any callable
+            args will first be evaluated and their return values passed.
+            This is useful for runtime configuration.
+    """
+    def decorate(target):
+        # change names because python 2.x doesn't have nonlocal
+        logger_ = logger
+        if isinstance(logger_, basestring):
+            logger_ = logging.getLogger(logger_)
+        on_success_ = _config_handlers(on_success)
+        on_backoff_ = _config_handlers(on_backoff, _log_backoff, logger_)
+        on_giveup_ = _config_handlers(on_giveup, _log_giveup, logger_)
+
+        retry = None
+        if sys.version_info >= (3, 5):  # pragma: python=3.5
+            import asyncio
+
+            if asyncio.iscoroutinefunction(target):
+                import backoff._async
+                retry = backoff._async.retry_predicate
+
+        if retry is None:
+            retry = _sync.retry_predicate
+
+        return retry(target, wait_gen, predicate,
+                     max_tries, max_time, jitter,
+                     on_success_, on_backoff_, on_giveup_,
+                     wait_gen_kwargs)
+
+    # Return a function which decorates a target with a retry loop.
+    return decorate
+
+
+def on_exception(wait_gen,
+                 exception,
+                 max_tries=None,
+                 max_time=None,
+                 jitter=full_jitter,
+                 giveup=lambda e: False,
+                 on_success=None,
+                 on_backoff=None,
+                 on_giveup=None,
+                 logger='backoff',
+                 **wait_gen_kwargs):
+    """Returns decorator for backoff and retry triggered by exception.
+
+    Args:
+        wait_gen: A generator yielding successive wait times in
+            seconds.
+        exception: An exception type (or tuple of types) which triggers
+            backoff.
+        max_tries: The maximum number of attempts to make before giving
+            up. Once exhausted, the exception will be allowed to escape.
+            The default value of None means their is no limit to the
+            number of tries. If a callable is passed, it will be
+            evaluated at runtime and its return value used.
+        max_time: The maximum total amount of time to try for before
+            giving up. Once expired, the exception will be allowed to
+            escape. If a callable is passed, it will be
+            evaluated at runtime and its return value used.
+        jitter: A function of the value yielded by wait_gen returning
+            the actual time to wait. This distributes wait times
+            stochastically in order to avoid timing collisions across
+            concurrent clients. Wait times are jittered by default
+            using the full_jitter function. Jittering may be disabled
+            altogether by passing jitter=None.
+        giveup: Function accepting an exception instance and
+            returning whether or not to give up. Optional. The default
+            is to always continue.
+        on_success: Callable (or iterable of callables) with a unary
+            signature to be called in the event of success. The
+            parameter is a dict containing details about the invocation.
+        on_backoff: Callable (or iterable of callables) with a unary
+            signature to be called in the event of a backoff. The
+            parameter is a dict containing details about the invocation.
+        on_giveup: Callable (or iterable of callables) with a unary
+            signature to be called in the event that max_tries
+            is exceeded.  The parameter is a dict containing details
+            about the invocation.
+        logger: Name or Logger object to log to. Defaults to 'backoff'.
+        **wait_gen_kwargs: Any additional keyword args specified will be
+            passed to wait_gen when it is initialized.  Any callable
+            args will first be evaluated and their return values passed.
+            This is useful for runtime configuration.
+    """
+    def decorate(target):
+        # change names because python 2.x doesn't have nonlocal
+        logger_ = logger
+        if isinstance(logger_, basestring):
+            logger_ = logging.getLogger(logger_)
+        on_success_ = _config_handlers(on_success)
+        on_backoff_ = _config_handlers(on_backoff, _log_backoff, logger_)
+        on_giveup_ = _config_handlers(on_giveup, _log_giveup, logger_)
+
+        retry = None
+        if sys.version_info[:2] >= (3, 5):   # pragma: python=3.5
+            import asyncio
+
+            if asyncio.iscoroutinefunction(target):
+                import backoff._async
+                retry = backoff._async.retry_exception
+
+        if retry is None:
+            retry = _sync.retry_exception
+
+        return retry(target, wait_gen, exception,
+                     max_tries, max_time, jitter, giveup,
+                     on_success_, on_backoff_, on_giveup_,
+                     wait_gen_kwargs)
+
+    # Return a function which decorates a target with a retry loop.
+    return decorate

--- a/lib/backoff/_jitter.py
+++ b/lib/backoff/_jitter.py
@@ -1,0 +1,28 @@
+# coding:utf-8
+
+import random
+
+
+def random_jitter(value):
+    """Jitter the value a random number of milliseconds.
+
+    This adds up to 1 second of additional time to the original value.
+    Prior to backoff version 1.2 this was the default jitter behavior.
+
+    Args:
+        value: The unadulterated backoff value.
+    """
+    return value + random.random()
+
+
+def full_jitter(value):
+    """Jitter the value across the full range (0 to value).
+
+    This corresponds to the "Full Jitter" algorithm specified in the
+    AWS blog's post on the performance of various jitter algorithms.
+    (http://www.awsarchitectureblog.com/2015/03/backoff.html)
+
+    Args:
+        value: The unadulterated backoff value.
+    """
+    return random.uniform(0, value)

--- a/lib/backoff/_sync.py
+++ b/lib/backoff/_sync.py
@@ -1,0 +1,117 @@
+# coding:utf-8
+import datetime
+import functools
+import time
+from datetime import timedelta
+
+from backoff._common import (_init_wait_gen, _maybe_call, _next_wait)
+
+
+def _call_handlers(hdlrs, target, args, kwargs, tries, elapsed, **extra):
+    details = {
+        'target': target,
+        'args': args,
+        'kwargs': kwargs,
+        'tries': tries,
+        'elapsed': elapsed,
+    }
+    details.update(extra)
+    for hdlr in hdlrs:
+        hdlr(details)
+
+
+def retry_predicate(target, wait_gen, predicate,
+                    max_tries, max_time, jitter,
+                    on_success, on_backoff, on_giveup,
+                    wait_gen_kwargs):
+
+    @functools.wraps(target)
+    def retry(*args, **kwargs):
+
+        # change names because python 2.x doesn't have nonlocal
+        max_tries_ = _maybe_call(max_tries)
+        max_time_ = _maybe_call(max_time)
+
+        tries = 0
+        start = datetime.datetime.now()
+        wait = _init_wait_gen(wait_gen, wait_gen_kwargs)
+        while True:
+            tries += 1
+            elapsed = timedelta.total_seconds(datetime.datetime.now() - start)
+            details = (target, args, kwargs, tries, elapsed)
+
+            ret = target(*args, **kwargs)
+            if predicate(ret):
+                max_tries_exceeded = (tries == max_tries_)
+                max_time_exceeded = (max_time_ is not None and
+                                     elapsed >= max_time_)
+
+                if max_tries_exceeded or max_time_exceeded:
+                    _call_handlers(on_giveup, *details, value=ret)
+                    break
+
+                try:
+                    seconds = _next_wait(wait, jitter, elapsed, max_time_)
+                except StopIteration:
+                    _call_handlers(on_giveup, *details)
+                    break
+
+                _call_handlers(on_backoff, *details,
+                               value=ret, wait=seconds)
+
+                time.sleep(seconds)
+                continue
+            else:
+                _call_handlers(on_success, *details, value=ret)
+                break
+
+        return ret
+
+    return retry
+
+
+def retry_exception(target, wait_gen, exception,
+                    max_tries, max_time, jitter, giveup,
+                    on_success, on_backoff, on_giveup,
+                    wait_gen_kwargs):
+
+    @functools.wraps(target)
+    def retry(*args, **kwargs):
+
+        # change names because python 2.x doesn't have nonlocal
+        max_tries_ = _maybe_call(max_tries)
+        max_time_ = _maybe_call(max_time)
+
+        tries = 0
+        start = datetime.datetime.now()
+        wait = _init_wait_gen(wait_gen, wait_gen_kwargs)
+        while True:
+            tries += 1
+            elapsed = timedelta.total_seconds(datetime.datetime.now() - start)
+            details = (target, args, kwargs, tries, elapsed)
+
+            try:
+                ret = target(*args, **kwargs)
+            except exception as e:
+                max_tries_exceeded = (tries == max_tries_)
+                max_time_exceeded = (max_time_ is not None and
+                                     elapsed >= max_time_)
+
+                if giveup(e) or max_tries_exceeded or max_time_exceeded:
+                    _call_handlers(on_giveup, *details)
+                    raise
+
+                try:
+                    seconds = _next_wait(wait, jitter, elapsed, max_time_)
+                except StopIteration:
+                    _call_handlers(on_giveup, *details)
+                    raise e
+
+                _call_handlers(on_backoff, *details, wait=seconds)
+
+                time.sleep(seconds)
+            else:
+                _call_handlers(on_success, *details)
+
+                return ret
+    return retry

--- a/lib/backoff/_wait_gen.py
+++ b/lib/backoff/_wait_gen.py
@@ -1,0 +1,56 @@
+# coding:utf-8
+
+import itertools
+
+
+def expo(base=2, factor=1, max_value=None):
+    """Generator for exponential decay.
+
+    Args:
+        base: The mathematical base of the exponentiation operation
+        factor: Factor to multiply the exponentation by.
+        max_value: The maximum value to yield. Once the value in the
+             true exponential sequence exceeds this, the value
+             of max_value will forever after be yielded.
+    """
+    n = 0
+    while True:
+        a = factor * base ** n
+        if max_value is None or a < max_value:
+            yield a
+            n += 1
+        else:
+            yield max_value
+
+
+def fibo(max_value=None):
+    """Generator for fibonaccial decay.
+
+    Args:
+        max_value: The maximum value to yield. Once the value in the
+             true fibonacci sequence exceeds this, the value
+             of max_value will forever after be yielded.
+    """
+    a = 1
+    b = 1
+    while True:
+        if max_value is None or a < max_value:
+            yield a
+            a, b = b, a + b
+        else:
+            yield max_value
+
+
+def constant(interval=1):
+    """Generator for constant intervals.
+
+    Args:
+        interval: A constant value to yield or an iterable of such values.
+    """
+    try:
+        itr = iter(interval)
+    except TypeError:
+        itr = itertools.repeat(interval)
+
+    for val in itr:
+        yield val

--- a/start.py
+++ b/start.py
@@ -29,7 +29,7 @@ from m2ee import M2EE, logger  # noqa: E402
 from nginx import get_path_config, gen_htpasswd  # noqa: E402
 from buildpackutil import i_am_primary_instance  # noqa: E402
 
-BUILDPACK_VERSION = "4.3.2"
+BUILDPACK_VERSION = "4.3.3"
 
 
 logger.setLevel(buildpackutil.get_buildpack_loglevel())


### PR DESCRIPTION
This PR adds an exponential backoff for awaiting the Datadog log subscriber. This supersedes the sleep of 5 seconds introduced in the previous PR.

Addtionally, the Datadog integration tests now test if all expected Datadog ports are producing smoke.