### PR TITLE
[DEP-2844] Update Datadog sidecar to 0.21.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install:
   - pip3 install -r tests/requirements.txt
 
 before_script:
+  - curl ifconfig.co
   - make login
 
 script:

--- a/lib/datadog.py
+++ b/lib/datadog.py
@@ -10,7 +10,7 @@ import buildpackutil
 import database_config
 from m2ee import logger
 
-DD_SIDECAR = "cf-datadog-sidecar-v0.21.1_master_98363.tar.gz"
+DD_SIDECAR = "cf-datadog-sidecar-v0.21.2_master_103662.tar.gz"
 MX_AGENT_JAR = "mx-java-agent.jar"
 DD_AGENT_JAR = "dd-java-agent.jar"
 

--- a/start.py
+++ b/start.py
@@ -29,7 +29,7 @@ from m2ee import M2EE, logger  # noqa: E402
 from nginx import get_path_config, gen_htpasswd  # noqa: E402
 from buildpackutil import i_am_primary_instance  # noqa: E402
 
-BUILDPACK_VERSION = "4.3.3"
+BUILDPACK_VERSION = "4.3.4"
 
 
 logger.setLevel(buildpackutil.get_buildpack_loglevel())


### PR DESCRIPTION
This adds a new version of the Datadog sidecar for internal issue DEP-2844.
It removes the default value for the DD_DD_URL environment variable set in the sidecar. This enables buildpack users to set the DD_SITE environment variable to select their Datadog region their org is in.