### PR TITLE
Download Mendix runtimes from download.mendix.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,9 +180,9 @@ If you are running Cloud Foundry without a connection to the Internet, you shoul
 
 `BLOBSTORE: https://my-intranet-webserver.my-company.com/mendix/`
 
-The preferred way to set up this on-premises web server is as a transparent proxy to `https://cdn.mendix.com/`. This prevents manual work by system administrators every time a new Mendix version is released.
+The preferred way to set up this on-premises web server is as a transparent proxy to `https://cdn.mendix.com/` and `https://download.mendix.com/`. This prevents manual work by system administrators every time a new Mendix version is released.
 
-Alternatively you can make the required mendix runtime files `mendix-VERSION.tar.gz` available under `BLOBSTORE/runtime/`. The original files can be downloaded from `https://cdn.mendix.com/`. You should also make the Java version available on:
+Alternatively you can make the required Mendix runtime files `mendix-VERSION.tar.gz` available under `BLOBSTORE/runtimes/`. The original files can be downloaded from `https://download.mendix.com/`. You should also make the Java version available on:
 * `BLOBSTORE/mx-buildpack/jre-8-linux-x64.tar.gz`
 * `BLOBSTORE/mx-buildpack/jdk-8-linux-x64.tar.gz`
 

--- a/bin/compile.py
+++ b/bin/compile.py
@@ -166,7 +166,7 @@ def download_mendix_version():
     else:
         cache_dir = CACHE_DIR
         url = buildpackutil.get_blobstore_url(
-            "/runtime/mendix-%s.tar.gz" % str(get_runtime_version())
+            "/runtimes/mendix-%s.tar.gz" % str(get_runtime_version()), True
         )
     logging.debug(
         "rootfs without mendix runtimes detected, "

--- a/lib/buildpackutil.py
+++ b/lib/buildpackutil.py
@@ -80,8 +80,11 @@ def get_appname():
     )
 
 
-def get_blobstore_url(filename):
-    main_url = os.environ.get("BLOBSTORE", "https://cdn.mendix.com")
+def get_blobstore_url(filename, is_runtime=False):
+    site = "https://cdn.mendix.com"
+    if is_runtime:
+        site = "https://download.mendix.com"
+    main_url = os.environ.get("BLOBSTORE", site)
     if main_url[-1] == "/":
         main_url = main_url[0:-1]
     return main_url + filename
@@ -235,7 +238,7 @@ def ensure_mxbuild_in_directory(directory, mx_version, cache_dir):
             logging.debug(str(e))
             download_and_unpack(
                 get_blobstore_url(
-                    "/runtime/mxbuild-%s.tar.gz" % str(mx_version)
+                    "/runtimes/mxbuild-%s.tar.gz" % str(mx_version), True
                 ),
                 directory,
                 cache_dir=cache_dir,

--- a/start.py
+++ b/start.py
@@ -29,7 +29,7 @@ from m2ee import M2EE, logger  # noqa: E402
 from nginx import get_path_config, gen_htpasswd  # noqa: E402
 from buildpackutil import i_am_primary_instance  # noqa: E402
 
-BUILDPACK_VERSION = "4.4.0"
+BUILDPACK_VERSION = "4.4.1"
 
 
 logger.setLevel(buildpackutil.get_buildpack_loglevel())
@@ -857,7 +857,7 @@ def set_up_m2ee_client(vcap_data):
                     "Unable to fetch Mendix {} using git".format(version)
                 )
                 url = buildpackutil.get_blobstore_url(
-                    "/runtime/mendix-%s.tar.gz" % str(version)
+                    "/runtimes/mendix-%s.tar.gz" % str(version), True
                 )
                 logger.info(
                     "Fallback (2): downloading Mendix {} from {}".format(


### PR DESCRIPTION
This PR closes internal issue DEP-2858 and makes Mendix runtimes come from download.mendix.com.