### PR TITLE
Changes for SameSite cookies in runtimes < 8.11

### DIFF
--- a/buildpack/nginx.py
+++ b/buildpack/nginx.py
@@ -41,7 +41,7 @@ def set_up_files(m2ee):
         lines = "".join(fh.readlines())
 
     samesite_cookie_workaround = get_path_config(
-        MXVersion(str(m2ee.config.get_runtime_version())) < MXVersion("8.10")
+        MXVersion(str(m2ee.config.get_runtime_version())) < MXVersion("8.11")
     )
     http_headers = parse_headers(samesite_cookie_workaround)
     lines = (

--- a/buildpack/nginx.py
+++ b/buildpack/nginx.py
@@ -19,6 +19,8 @@ DEFAULT_HEADERS = {
     "X-XSS-Protection": r"(?i)(^0$|^1$|^1; mode=block$|^1; report=https?://([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*(:\d+)?$)",  # noqa: E501
 }
 
+SAMESITE_COOKIE_WORKAROUND_HEADER = 'add_header Set-Cookie "mx-cookie-test=allowed; SameSite=None; Secure; Path=/" always;\n'
+
 
 def compile(build_path, cache_path):
     util.download_and_unpack(
@@ -103,9 +105,7 @@ def parse_headers(samesite_cookie_workaround=False):
             )
 
     if samesite_cookie_workaround:
-        header_value = 'add_header Set-Cookie "mx-cookie-test=allowed; SameSite=None; Secure; Path=/" always;\n'
-        escaped_value = header_value.replace('"', '\\"').replace("'", "\\'")
-        header_config += escaped_value
+        header_config += SAMESITE_COOKIE_WORKAROUND_HEADER
 
     return header_config
 

--- a/buildpack/nginx.py
+++ b/buildpack/nginx.py
@@ -19,7 +19,12 @@ DEFAULT_HEADERS = {
     "X-XSS-Protection": r"(?i)(^0$|^1$|^1; mode=block$|^1; report=https?://([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*(:\d+)?$)",  # noqa: E501
 }
 
-SAMESITE_COOKIE_WORKAROUND_HEADER = 'add_header Set-Cookie "mx-cookie-test=allowed; SameSite=None; Secure; Path=/" always;\n'
+# Fix for Chrome SameSite enforcement (runtime will set this cookie in newer runtime versions)
+SAMESITE_COOKIE_WORKAROUND_LESS_MX_VERSION = "8.11"
+SAMESITE_COOKIE_WORKAROUND_HEADER = 'add_header Set-Cookie "mx-cookie-test=allowed; SameSite=None; Secure; Path=/" always;'
+SAMESITE_COOKIE_WORKAROUND_PROXY_PASS = (
+    'proxy_cookie_path ~(.*) "$1; SameSite=None; Secure; HttpOnly";'
+)
 
 
 def compile(build_path, cache_path):
@@ -42,12 +47,13 @@ def set_up_files(m2ee):
     with open("nginx/conf/nginx.conf") as fh:
         lines = "".join(fh.readlines())
 
-    samesite_cookie_workaround = get_path_config(
-        MXVersion(str(m2ee.config.get_runtime_version())) < MXVersion("8.11")
-    )
+    samesite_cookie_workaround = MXVersion(
+        str(m2ee.config.get_runtime_version())
+    ) < MXVersion(SAMESITE_COOKIE_WORKAROUND_LESS_MX_VERSION)
+
     http_headers = parse_headers(samesite_cookie_workaround)
     lines = (
-        lines.replace("CONFIG", samesite_cookie_workaround,)
+        lines.replace("CONFIG", get_path_config(samesite_cookie_workaround))
         .replace("NGINX_PORT", str(util.get_nginx_port()))
         .replace("RUNTIME_PORT", str(util.get_runtime_port()))
         .replace("ADMIN_PORT", str(util.get_admin_port()))
@@ -105,7 +111,7 @@ def parse_headers(samesite_cookie_workaround=False):
             )
 
     if samesite_cookie_workaround:
-        header_config += SAMESITE_COOKIE_WORKAROUND_HEADER
+        header_config += SAMESITE_COOKIE_WORKAROUND_HEADER + "\n"
 
     return header_config
 
@@ -230,10 +236,9 @@ satisfy %s;
         if config.get("client-cert") or config.get("client_cert"):
             client_cert = "auth_request /client-cert-check-internal;"
 
-        # Temporary fix for SameSite enforcement (runtime will set this cookie from 8.10 onwards)
         proxy_cookie_samesite = None
         if samesite_cookie_workaround:
-            proxy_cookie_samesite = 'proxy_cookie_path ~(.*) "$1; SameSite=None; Secure; HttpOnly";'
+            proxy_cookie_samesite = SAMESITE_COOKIE_WORKAROUND_PROXY_PASS
 
         template = root_template if path == "/" else location_template
         indent = "\n" + " " * (0 if path == "/" else 4)

--- a/buildpack/start.py
+++ b/buildpack/start.py
@@ -27,7 +27,7 @@ from buildpack import (
 from buildpack.runtime_components import security
 from lib.m2ee import M2EE as m2ee_class
 
-BUILDPACK_VERSION = "4.5.0"
+BUILDPACK_VERSION = "4.5.1"
 
 m2ee = None
 app_is_restarting = False

--- a/tests/unit/test_custom_headers.py
+++ b/tests/unit/test_custom_headers.py
@@ -154,3 +154,9 @@ class TestCaseCustomHeaderConfig(unittest.TestCase):
         os.environ["HTTP_RESPONSE_HEADERS"] = "invalid"
         with self.assertRaises(ValueError):
             nginx.parse_headers()
+
+    def test_samesite_cookie_workaround_header(self):
+        header_config = nginx.parse_headers(True)
+        self.assertIn(
+            nginx.SAMESITE_COOKIE_WORKAROUND_HEADER, header_config,
+        )


### PR DESCRIPTION
This PR is for internal issue DEP-2872 and "fixes" SameSite compliancy for Mendix applications with any runtime < 8.9.