### PR TITLE
Add deleting of old cached dependencies

### DIFF
--- a/lib/buildpackutil.py
+++ b/lib/buildpackutil.py
@@ -1,11 +1,12 @@
 import errno
 import json
+import glob
 import logging
 import os
 import platform
+import re
 import subprocess
 import sys
-import glob
 from distutils.util import strtobool
 
 sys.path.insert(0, "lib")
@@ -87,11 +88,37 @@ def get_blobstore_url(filename):
     return main_url + filename
 
 
+def _delete_other_versions(directory, file_name):
+    logging.debug(
+        "Deleting other versions than {} from {}...".format(
+            file_name, directory
+        )
+    )
+    expression = (
+        r"^((?:[a-zA-Z]+-)+)((?:v*[0-9]+\.{0,1})+.*)(\.(?:tar\.gz|tgz|zip))$"
+    )
+    groups = re.search(expression, file_name)
+
+    file_pattern = "%s/%s*%s" % (directory, groups[1], groups[3])
+    files = glob.glob(file_pattern)
+
+    for f in files:
+        if os.path.basename(f) != file_name:
+            logging.debug(
+                "Deleting version {} from {}...".format(
+                    os.path.basename(f), directory
+                )
+            )
+            os.remove(f)
+
+
 def download_and_unpack(url, destination, cache_dir="/tmp/downloads"):
     file_name = url.split("/")[-1]
     mkdir_p(cache_dir)
     mkdir_p(destination)
     cached_location = os.path.join(cache_dir, file_name)
+
+    _delete_other_versions(cache_dir, file_name)
 
     logging.debug(
         "Looking for {cached_location}".format(cached_location=cached_location)

--- a/lib/buildpackutil.py
+++ b/lib/buildpackutil.py
@@ -97,19 +97,19 @@ def _delete_other_versions(directory, file_name):
     expression = (
         r"^((?:[a-zA-Z]+-)+)((?:v*[0-9]+\.{0,1})+.*)(\.(?:tar\.gz|tgz|zip))$"
     )
-    groups = re.search(expression, file_name)
+    pattern = re.sub(expression, "\\1*\\3", file_name)
 
-    file_pattern = "%s/%s*%s" % (directory, groups[1], groups[3])
-    files = glob.glob(file_pattern)
+    if pattern:
+        files = glob.glob("{}/{}".format(directory, pattern))
 
-    for f in files:
-        if os.path.basename(f) != file_name:
-            logging.debug(
-                "Deleting version {} from {}...".format(
-                    os.path.basename(f), directory
+        for f in files:
+            if os.path.basename(f) != file_name:
+                logging.debug(
+                    "Deleting version {} from {}...".format(
+                        os.path.basename(f), directory
+                    )
                 )
-            )
-            os.remove(f)
+                os.remove(f)
 
 
 def download_and_unpack(url, destination, cache_dir="/tmp/downloads"):

--- a/start.py
+++ b/start.py
@@ -29,7 +29,7 @@ from m2ee import M2EE, logger  # noqa: E402
 from nginx import get_path_config, gen_htpasswd  # noqa: E402
 from buildpackutil import i_am_primary_instance  # noqa: E402
 
-BUILDPACK_VERSION = "4.4.0"
+BUILDPACK_VERSION = "4.4.1"
 
 
 logger.setLevel(buildpackutil.get_buildpack_loglevel())

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,7 @@
 backoff==1.10.0
 certifi==2019.3.9
 chardet==3.0.4
+cryptography==2.8
 idna==2.8
 nose-timer==0.7.4
 nose==1.3.7

--- a/tests/usecase/test_util.py
+++ b/tests/usecase/test_util.py
@@ -1,0 +1,41 @@
+import glob
+import os
+import tempfile
+import unittest
+
+from lib import buildpackutil
+
+
+class TestDatabaseConfigOptions(unittest.TestCase):
+    def test_delete_old_versions(self):
+        filenames = [
+            "a-a-1.0.tar.gz",
+            "a-a-1.1.tar.gz",
+            "a-a-1.2.zip",
+            "a-b-1.0.tar.gz",
+            "a-b-1.1.tar.gz",
+            "a-b-1.2.zip",
+        ]
+
+        temp_dir = tempfile.TemporaryDirectory()
+
+        files = []
+        for f in filenames:
+            files.append(os.path.join(temp_dir.name, f))
+
+        for f in files:
+            open(f, "a").close()
+
+        test_file = files[0]
+
+        buildpackutil._delete_other_versions(
+            temp_dir.name, os.path.basename(test_file)
+        )
+
+        files.remove(files[1])
+
+        result = glob.glob("%s/*.*" % temp_dir.name)
+
+        assert set(result) == set(files)
+
+        temp_dir.cleanup()

--- a/tests/usecase/test_util.py
+++ b/tests/usecase/test_util.py
@@ -6,36 +6,77 @@ import unittest
 from lib import buildpackutil
 
 
-class TestDatabaseConfigOptions(unittest.TestCase):
-    def test_delete_old_versions(self):
-        filenames = [
-            "a-a-1.0.tar.gz",
-            "a-a-1.1.tar.gz",
-            "a-a-1.2.zip",
-            "a-b-1.0.tar.gz",
-            "a-b-1.1.tar.gz",
-            "a-b-1.2.zip",
-        ]
+class TestUtil(unittest.TestCase):
 
+    # Works with a set of similar filenames only
+    def _test_delete_old_versions(
+        self, prefix, versions, index_to_keep, indexes_to_remove
+    ):
         temp_dir = tempfile.TemporaryDirectory()
 
         files = []
-        for f in filenames:
-            files.append(os.path.join(temp_dir.name, f))
+        for version in versions:
+            files.append(
+                os.path.join(temp_dir.name, "{}{}".format(prefix, version))
+            )
 
         for f in files:
             open(f, "a").close()
 
-        test_file = files[0]
+        test_file = files[index_to_keep]
 
         buildpackutil._delete_other_versions(
             temp_dir.name, os.path.basename(test_file)
         )
 
-        files.remove(files[1])
-
         result = glob.glob("%s/*.*" % temp_dir.name)
 
-        assert set(result) == set(files)
+        j = 0
+        for i in indexes_to_remove:
+            del files[i - j]
+            j += 1
 
         temp_dir.cleanup()
+
+        return set(result) == set(files)
+
+    def test_delete_old_versions(self):
+
+        # Example dependencies that we can expect:
+        # - AdoptOpenJDK-jre-11.0.3-linux-x64.tar.gz
+        # - mendix-8.4.1.63369.tar.gz
+        # - nginx-1.15.10-linux-x64-cflinuxfs2-6247377a.tgz
+        # - cf-datadog-sidecar-v0.21.2_master_103662.tar.gz
+
+        openjdk_prefix = "AdoptOpenJDK-jre-"
+        openjdk_versions = ["11.0.3-linux-x64.tar.gz"]
+
+        assert self._test_delete_old_versions(
+            openjdk_prefix, openjdk_versions, 0, {}
+        )
+
+        dd_prefix = "cf-datadog-sidecar-"
+        dd_versions = [
+            "v0.11.1_master_78318.tar.gz",
+            "v0.21.1_master_98363.tar.gz",
+            "v0.21.2_master_103662.zip",
+        ]
+
+        assert self._test_delete_old_versions(dd_prefix, dd_versions, 0, [1])
+
+        mx_prefix = "mendix-"
+        mx_versions = [
+            "8.4.1.63369.tar.gz",
+            "8.5.0.64176.tar.gz",
+            "8.6.1.1701.tar.gz",
+            "8.7.0.1476.tar.gz",
+        ]
+
+        assert self._test_delete_old_versions(
+            mx_prefix, mx_versions, 1, [0, 2, 3]
+        )
+
+        ng_prefix = "nginx-"
+        ng_versions = ["1.15.10-linux-x64-cflinuxfs2-6247377a.tgz"]
+
+        assert self._test_delete_old_versions(ng_prefix, ng_versions, 0, {})


### PR DESCRIPTION
This PR closed internal issue DEP-2887 and adds deleting of old dependencies out of the build cache. This should free up staging space for apps that are upgraded during their lifetimes (e.g. runtime and other dependencies).