### PR TITLE
Add metric to measure TCP latency between app and database

### DIFF
--- a/bin/bootstrap-python
+++ b/bin/bootstrap-python
@@ -25,12 +25,9 @@ PIP_WORKDIR="${CACHE_PATH}/pip/build"
 # Set the correct Python site-packages directory to install to
 SITE_PACKAGES_PATH="${BUILD_PATH}/$(python3 -m site --user-site | cut -d '/' -f4-)"
 
-if [[ ! -d $PIP_WHEELDIR ]]
-then
-    echo " ---> Copying included wheels to cache...";
-    mkdir -p $PIP_WHEELDIR;
-    cp -rf $WHEELS_PATH/* $PIP_WHEELDIR/; 
-fi
+echo " ---> Copying included wheels to cache...";
+mkdir -p $PIP_WHEELDIR;
+cp -rf $WHEELS_PATH/* $PIP_WHEELDIR/;
 
 echo " ---> Bootstrapping pip and setuptools..."
 $PIP_CMD install --user --no-warn-script-location --no-index --find-links=$PIP_WHEELDIR --build=$PIP_WORKDIR pip setuptools

--- a/buildpack/start.py
+++ b/buildpack/start.py
@@ -27,7 +27,7 @@ from buildpack import (
 from buildpack.runtime_components import security
 from lib.m2ee import M2EE as m2ee_class
 
-BUILDPACK_VERSION = "4.5.2"
+BUILDPACK_VERSION = "4.5.3"
 
 m2ee = None
 app_is_restarting = False

--- a/tests/integration/test_emit_metrics.py
+++ b/tests/integration/test_emit_metrics.py
@@ -25,6 +25,7 @@ class TestCaseEmitMetrics(basetest.BaseTest):
         self.assert_string_in_recent_logs("storage")
         self.assert_string_in_recent_logs("number_of_files")
         self.assert_string_in_recent_logs("critical_logs_count")
+        self.assert_string_in_recent_logs("tcp_latency")
 
     def test_free_apps_metrics(self):
         self.setUpCF(


### PR DESCRIPTION
1. Add TCP networking latency:
    * Measure TCP networking latency metric for database connection.
2. Always update buildpack with included pip packages:
    * With current implementation new pip packages from this repo will be ignored for applications with buildpack cache. `bootstrap-python` script should copy all packages every time compile script executed.
3. Check for tcp latency metric in `test_read_metrics_in_logs` integration test.