### PR TITLE
DVAS-1240: Raise RuntimeError for negative metrics

### DIFF
--- a/buildpack/runtime_components/metrics.py
+++ b/buildpack/runtime_components/metrics.py
@@ -189,6 +189,28 @@ class BaseMetricsEmitterThread(threading.Thread, metaclass=ABCMeta):
             health["diagnosis"] = "Health check failed unexpectedly: %s" % e
         return stats
 
+    @staticmethod
+    def _sanity_check_m2ee_stats(m2ee_stats):
+        """Memory usage can never be negative. If this happens, throw a warning
+        and ask the customer to contact support, so that we can debug.
+        """
+        for memory_type, memory_value in m2ee_stats["memory"].items():
+            if not isinstance(memory_value, int):
+                # Memorypools are here and are stored as a dict
+                continue
+
+            if memory_value < 0:
+                # memory value can be zero, but not negative
+                logging.error(
+                    "Memory stats with non-logical values: %s",
+                    m2ee_stats["memory"],
+                )
+                raise RuntimeError(
+                    "Memory statistics have non-logical values. This will "
+                    "cause incorrect data in your application's metrics. "
+                    "Please contact support!"
+                )
+
     def _inject_m2ee_stats(self, stats):
         try:
             m2ee_stats, java_version = munin.get_stats_from_runtime(
@@ -204,6 +226,7 @@ class BaseMetricsEmitterThread(threading.Thread, metaclass=ABCMeta):
                 self.m2ee.client.get_critical_log_messages()
             )
             m2ee_stats["critical_logs_count"] = critical_logs_count
+            self._sanity_check_m2ee_stats(m2ee_stats)
             stats["mendix_runtime"] = m2ee_stats
         except Exception:
             logging.debug("Unable to get metrics from runtime")

--- a/buildpack/start.py
+++ b/buildpack/start.py
@@ -27,7 +27,7 @@ from buildpack import (
 from buildpack.runtime_components import security
 from lib.m2ee import M2EE as m2ee_class
 
-BUILDPACK_VERSION = "4.6.2"
+BUILDPACK_VERSION = "4.6.3"
 
 m2ee = None
 app_is_restarting = False


### PR DESCRIPTION
Having negative metrics displayed does not make sense. If there are any more bugs in our metrics, Instead of storing negative metrics, we should throw an error, and request that the customer contacts support.

This will show blank metrics, instead of erroneous metrics. There will also be a clear message in the customer’s application logs, explaining that something is wrong. That will give the customer more certainty than the current situation, where they cannot trust their graphs.