### PR TITLE
DVAS-1246 postgresql input plugin for telegraf

### DIFF
--- a/buildpack/compile.py
+++ b/buildpack/compile.py
@@ -113,7 +113,7 @@ def copy_buildpack_resources():
         os.path.join(BUILD_DIR, "buildpack"),
     )
     shutil.copytree(
-        os.path.join(BUILDPACK_DIR, "lib"), os.path.join(BUILD_DIR, "lib"),
+        os.path.join(BUILDPACK_DIR, "lib"), os.path.join(BUILD_DIR, "lib")
     )
     shutil.copy(
         os.path.join(BUILDPACK_DIR, "bin", "mendix-logfilter"),

--- a/buildpack/datadog.py
+++ b/buildpack/datadog.py
@@ -270,7 +270,7 @@ def _set_up_environment():
         os.environ["DD_SERVICE_NAME"] = _get_service()
         os.environ["DD_JMXFETCH_ENABLED"] = "false"
         os.environ["DD_SERVICE_MAPPING"] = "{}:{}.db".format(
-            database.get_config()["DatabaseType"].lower(), _get_service(),
+            database.get_config()["DatabaseType"].lower(), _get_service()
         )
 
     e = dict(os.environ.copy())

--- a/buildpack/java.py
+++ b/buildpack/java.py
@@ -11,7 +11,7 @@ def compile(buildpack_path, cache_path, local_path, java_version):
     logging.debug("begin download and install java")
     util.mkdir_p(os.path.join(local_path, "bin"))
     jvm_location = ensure_and_get_jvm(
-        java_version, cache_path, local_path, package="jre",
+        java_version, cache_path, local_path, package="jre"
     )
     # create a symlink in .local/bin/java
     os.symlink(

--- a/buildpack/mxbuild.py
+++ b/buildpack/mxbuild.py
@@ -130,7 +130,7 @@ def start_mxbuild_server(local_path, runtime_version, java_version):
         path = os.path.join(local_path, "mxbuild")
 
     jvm_location = java.ensure_and_get_jvm(
-        java_version, cache, local_path, package="jdk",
+        java_version, cache, local_path, package="jdk"
     )
     subprocess.Popen(
         [

--- a/buildpack/start.py
+++ b/buildpack/start.py
@@ -27,7 +27,7 @@ from buildpack import (
 from buildpack.runtime_components import security
 from lib.m2ee import M2EE as m2ee_class
 
-BUILDPACK_VERSION = "4.5.6"
+BUILDPACK_VERSION = "4.5.7"
 
 m2ee = None
 app_is_restarting = False

--- a/buildpack/telegraf.py
+++ b/buildpack/telegraf.py
@@ -37,8 +37,10 @@ from buildpack.runtime_components import database
 def _get_appmetrics_target():
     return os.getenv("APPMETRICS_TARGET")
 
+
 def include_db_metrics():
     return os.getenv("APPMETRICS_INCLUDE_DB", "true").lower() == "true"
+
 
 def is_enabled():
     return _get_appmetrics_target() is not None
@@ -196,8 +198,10 @@ def update_config(m2ee, app_name):
                     db_config["DatabaseUserName"],
                     db_config["DatabasePassword"],
                     db_config["DatabaseHost"],
-                    db_config["DatabaseName"])
-            })
+                    db_config["DatabaseName"],
+                )
+            },
+        )
 
     # Forward metrics also to DataDog when enabled
     if datadog.is_enabled():


### PR DESCRIPTION
* Add input plugin in telegraf config for postgresql
* If **APPMETRICS_TARGET** is set, the database metrics will be enabled by default in telegraf. To opt out, set **APPMETRICS_INCLUDE_DB** to **False**


Tested by configuring an output plugin to write to file and verifying that metrics are being written.