### PR TITLE
[DEP-3015] Remove JDBC string from parsing exception to prevent credential leaks

### DIFF
--- a/buildpack/runtime_components/database.py
+++ b/buildpack/runtime_components/database.py
@@ -272,8 +272,7 @@ class UrlDatabaseConfiguration(DatabaseConfiguration):
                 break
         else:
             raise Exception(
-                "Could not parse database credentials from database uri %s"
-                % self.url
+                "Could not parse database credentials from database URI"
             )
 
         database_type_input = match.group("type")

--- a/buildpack/start.py
+++ b/buildpack/start.py
@@ -27,7 +27,7 @@ from buildpack import (
 from buildpack.runtime_components import security
 from lib.m2ee import M2EE as m2ee_class
 
-BUILDPACK_VERSION = "4.5.7"
+BUILDPACK_VERSION = "4.5.8"
 
 m2ee = None
 app_is_restarting = False


### PR DESCRIPTION
This PR resolves internal ticket DEP-3015 and prevents database credentials from leaking into logs in a scenario where a customer uses the buildpack outside of the Mendix Public Cloud.