### PR TITLE
DVAS-1241: Bug fix to address negative metrics issue

### DIFF
--- a/buildpack/start.py
+++ b/buildpack/start.py
@@ -27,7 +27,7 @@ from buildpack import (
 from buildpack.runtime_components import security
 from lib.m2ee import M2EE as m2ee_class
 
-BUILDPACK_VERSION = "4.6.1"
+BUILDPACK_VERSION = "4.6.2"
 
 m2ee = None
 app_is_restarting = False


### PR DESCRIPTION

- Re-arrange the code a bit, to have minimal control flow branching

- Code cache is allocated out of native memory and
is not part of the java heap. So as previously thought
we should not remove the code cache space from java heap
when calculating the unused java heap.

- Similarly, since Java 8 metaspace (or permanent gen)
is allocated out of the native memory. So we should not
negate that space from the native memory calculations.