### PR TITLE
Use MemoryMXBean's committed_heap metric to calculate free unused java heap

### DIFF
--- a/buildpack/start.py
+++ b/buildpack/start.py
@@ -27,7 +27,7 @@ from buildpack import (
 from buildpack.runtime_components import security
 from lib.m2ee import M2EE as m2ee_class
 
-BUILDPACK_VERSION = "4.7.0"
+BUILDPACK_VERSION = "4.7.1"
 
 m2ee = None
 app_is_restarting = False


### PR DESCRIPTION
Currently we calculate the free _unused java heap_ metric by comparing `java heap` value from the `/proc/PID/smaps` file and the `used_heap` value from the `MemoryMxBean` interface. This at times results in `negative unused java heap`

Instead of relying on two different methodologies to gather metrics, simply use the `committed_heap` metric we have from the
[MemoryMXBean interface](https://cr.openjdk.java.net/~iris/se/11/latestSpec/api/java.management/java/lang/management/MemoryUsage.html) to calculate the free unused java heap.

Add tests to ensure we calculate free unused heap using committed_heap.

Bump version 4.7.0 → 4.7.1