### PR TITLE
README: fix examples of MXRUNTIME_* variable usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Note that not all databases are automatically picked up by the buildpack. If `cf
 
 ``` shell
 cf set-env <YOUR_APP> MXRUNTIME_DatabaseType PostgreSQL
-cf set-env <YOUR_APP> MXRUNTIME_DatabaseJdbcUrl postgres://host/databasename
+cf set-env <YOUR_APP> MXRUNTIME_DatabaseJdbcUrl jdbc:postgresql://host/databasename
 cf set-env <YOUR_APP> MXRUNTIME_DatabaseName databasename
 cf set-env <YOUR_APP> MXRUNTIME_DatabaseUserName user
 cf set-env <YOUR_APP> MXRUNTIME_DatabasePassword password

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Note that not all databases are automatically picked up by the buildpack. If `cf
 ``` shell
 cf set-env <YOUR_APP> MXRUNTIME_DatabaseType PostgreSQL
 cf set-env <YOUR_APP> MXRUNTIME_DatabaseJdbcUrl postgres://host/databasename
-cf set-env <YOUR_APP> MXRUNTIME_DatabaseUsername user
+cf set-env <YOUR_APP> MXRUNTIME_DatabaseUserName user
 cf set-env <YOUR_APP> MXRUNTIME_DatabasePassword password
 ```
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Note that not all databases are automatically picked up by the buildpack. If `cf
 ``` shell
 cf set-env <YOUR_APP> MXRUNTIME_DatabaseType PostgreSQL
 cf set-env <YOUR_APP> MXRUNTIME_DatabaseJdbcUrl postgres://host/databasename
+cf set-env <YOUR_APP> MXRUNTIME_DatabaseName databasename
 cf set-env <YOUR_APP> MXRUNTIME_DatabaseUserName user
 cf set-env <YOUR_APP> MXRUNTIME_DatabasePassword password
 ```

--- a/tests/unit/test_db_config_options.py
+++ b/tests/unit/test_db_config_options.py
@@ -33,7 +33,7 @@ class TestDatabaseConfigOptions(unittest.TestCase):
         os.environ["MXRUNTIME_DatabaseType"] = "PostgreSQL"
         os.environ[
             "MXRUNTIME_DatabaseJdbcUrl"
-        ] = "postgres://username:password@rdsbroker-testfree-nonprod-1-eu-west-1.asdbjasdg.eu-west-1.rds.amazonaws.com:5432/testdatabase"  # noqa E501
+        ] = "jdbc:postgresql://username:password@rdsbroker-testfree-nonprod-1-eu-west-1.asdbjasdg.eu-west-1.rds.amazonaws.com:5432/testdatabase"  # noqa E501
 
         config = get_config()
         assert not config


### PR DESCRIPTION
The examples shown in README.md just didn't work. The commit messages explain which Mendix Runtime errors I ran into.