### PR TITLE
Add Action for Veracode integration

### DIFF
--- a/.github/workflows/veracodescan.yml
+++ b/.github/workflows/veracodescan.yml
@@ -1,0 +1,41 @@
+name: Push package for veracode scan
+
+on: 
+  pull_request:
+    types: [closed]
+    branches:
+      - master
+
+jobs:
+  pre:
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.skip-check.outputs.should_skip }}
+    steps:
+    - id: skip-check
+      uses: fkirc/skip-duplicate-actions@master
+      with:
+        github_token: ${{ github.token }}
+        paths_ignore: '["**.md", "dev/**"]'
+  veracode-scan:
+    name: veracode scan
+    runs-on: ubuntu-latest
+    needs: pre
+    steps:
+      - name: Download pull request artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: test.yml
+          pr: ${{github.event.pull_request.number}}
+          name: dist
+      - name: Upload and scan
+        uses: veracode/veracode-uploadandscan-action@master
+        with:
+          filepath: 'cf-mendix-buildpack.zip'
+          vid: '${{ secrets.VERACODE_API_ID }}'
+          vkey: '${{ secrets.VERACODE_API_KEY }}'
+          appname: '${{ secrets.VERACODE_APP_NAME }}'
+          sandboxid: '${{ secrets.VERACODE_SANDBOX_ID }}'
+          scantimeout: 15
+          criticality: 'VeryLow'
+          


### PR DESCRIPTION
This change adds a Github Action which will get executed on every merge to master and will push the buildpack code to Veracode for security scanning.

This change is part of internal ticket DEP-3201.