### PR TITLE
Update Datadog sidecar

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ Additionally, we configure the following Datadog environment variables for you:
 
 | Environment Variable | Value | Can Be Overridden? | Description |
 |-|-|-|-|
-| `DD_ENABLE_CHECKS` | `true` | No | Enables integrated Datadog Agent Checks (logs, system metrics, PostgreSQL and JMX) |
+| `DD_ENABLE_USER_CHECKS` | `true` | No | Enables logs and PostgreSQL, JMX checks |
 | `DD_HOSTNAME` | `<app>-<env>.mendixcloud.com-<instance>` | No | Human-readable host name for your application |
 | `DD_JMXFETCH_ENABLED` | `false` | No | Disables Datadog Java Trace Agent JMX metrics fetching, since this is already handled by the Mendix Runtime. |
 | `DD_LOGS_ENABLED` | `true` | No | Enables sending your application logs directly to Datadog |

--- a/buildpack/datadog.py
+++ b/buildpack/datadog.py
@@ -20,7 +20,7 @@ from buildpack.runtime_components import database
 
 NAMESPACE = "datadog"
 
-SIDECAR_VERSION = "v0.22.0"
+SIDECAR_VERSION = "v0.22.1"
 SIDECAR_ARCHIVE = "cf-datadog-sidecar-{}.tar.gz".format(SIDECAR_VERSION)
 JAVA_AGENT_VERSION = "0.68.0"
 JAVA_AGENT_JAR = "dd-java-agent-{}.jar".format(JAVA_AGENT_VERSION)
@@ -31,6 +31,7 @@ ROOT_DIR = os.path.abspath(".local")
 SIDECAR_ROOT_DIR = os.path.join(ROOT_DIR, NAMESPACE)
 AGENT_DIR = os.path.join(SIDECAR_ROOT_DIR, "datadog")
 AGENT_CONF_DIR = os.path.join(AGENT_DIR, "etc", "datadog-agent")
+AGENT_CONFD_DIR = os.path.join(AGENT_CONF_DIR, "conf.d")
 AGENT_CHECKS_CONF_DIR = os.path.abspath("/home/vcap/app/datadog_integrations")
 
 LOGS_PORT = 9032
@@ -98,13 +99,15 @@ def _set_up_database_diskstorage():
     # This check is a very dirty workaround
     # and makes an environment variable into a gauge with a fixed value.
     if _is_database_diskstorage_enabled():
+        os.makedirs(AGENT_CHECKS_CONF_DIR, exist_ok=True)
         with open(
-            AGENT_CHECKS_CONF_DIR + "mx_database_diskstorage.yml", "w"
+            AGENT_CHECKS_CONF_DIR + "/mx_database_diskstorage.yml", "w"
         ) as fh:
             config = {
                 "init_config": {},
                 "instances": [{"min_collection_interval": 15}],
             }
+            fh.write(yaml.safe_dump(config))
 
 
 def _set_up_jmx():

--- a/buildpack/datadog.py
+++ b/buildpack/datadog.py
@@ -292,9 +292,6 @@ def _set_up_environment():
         e["DD_TRACE_ENABLED"] = "false"
     e["DD_LOGS_ENABLED"] = "true"
     e["DD_LOG_FILE"] = "/dev/null"
-    tags = util.get_tags()
-    if tags:
-        e["DD_TAGS"] = ",".join(tags)
     e["DD_PROCESS_CONFIG_LOG_FILE"] = "/dev/null"
     e["DD_DOGSTATSD_PORT"] = str(_get_statsd_port())
 

--- a/buildpack/stage.py
+++ b/buildpack/stage.py
@@ -166,7 +166,7 @@ if __name__ == "__main__":
     newrelic.stage(DOT_LOCAL_LOCATION, CACHE_DIR)
     mx_java_agent.stage(DOT_LOCAL_LOCATION, CACHE_DIR)
     telegraf.stage(DOT_LOCAL_LOCATION, CACHE_DIR)
-    datadog.stage(DOT_LOCAL_LOCATION, CACHE_DIR)
+    datadog.stage(BUILDPACK_DIR, DOT_LOCAL_LOCATION, CACHE_DIR)
     runtime.stage(BUILDPACK_DIR, BUILD_DIR, CACHE_DIR)
     databroker.stage(DOT_LOCAL_LOCATION, CACHE_DIR)
     nginx.stage(BUILDPACK_DIR, BUILD_DIR, CACHE_DIR)

--- a/etc/datadog/checks.d/mx_database_diskstorage.py
+++ b/etc/datadog/checks.d/mx_database_diskstorage.py
@@ -1,0 +1,20 @@
+import os
+
+try:
+    from datadog_checks.base import AgentCheck
+except ImportError:
+    from checks import AgentCheck
+
+__version__ = "1.0.0"
+
+
+class DatabaseDiskStorageCheck(AgentCheck):
+    def check(self, instance):
+        if "DATABASE_DISKSTORAGE" in os.environ:
+            try:
+                self.gauge(
+                    "mx.database.diskstorage_size",
+                    float(os.environ["DATABASE_DISKSTORAGE"]),
+                )
+            except ValueError:
+                pass


### PR DESCRIPTION
Update to the new and improved Datadog sidecar:
- Datadog Agent version updated to 7.23
- Removed Datadog and Mendix Java Agents from sidecar (they are now a separate dependency)
- Moved the Mendix database diskspace check to the buildpack
- Removed tag retrieval from the buildpack as this is already handled by the sidecar