### PR TITLE
Dynatrace bugfix and improve reliability

### DIFF
--- a/buildpack/dynatrace.py
+++ b/buildpack/dynatrace.py
@@ -26,11 +26,17 @@ def stage(buildpack_path, build_path):
             token=os.environ.get("DT_PAAS_TOKEN"),
         )
 
-        util.download_and_unpack(
-            agent_url,
-            buildpack_path,  # DOT_LOCAL_LOCATION,
-            build_path,  # CACHE_DIR,
-        )
+        try:
+            util.download_and_unpack(
+                agent_url,
+                buildpack_path,  # DOT_LOCAL_LOCATION,
+                cache_dir=build_path,  # CACHE_DIR,
+                unpack=True,
+            )
+        except Exception as e:
+            logging.warning(
+                "Dynatrace agent download and unpack failed", exc_info=True
+            )
 
 
 def update_config(m2ee, app_name):
@@ -39,8 +45,15 @@ def update_config(m2ee, app_name):
             "Skipping Dynatrace setup, no DT_TENANTTOKEN found in environment"
         )
         return
-    logging.info("Adding Dynatrace")
-    manifest = get_manifest()
+    logging.info("Enabling Dynatrace")
+    try:
+        manifest = get_manifest()
+    except Exception as e:
+        logging.warning(
+            "Failed to parse Dynatrace manifest file", exc_info=True
+        )
+        return
+
     # dynamic default
     default_env.update({"DT_TENANTTOKEN": manifest.get("tenantToken")})
 

--- a/buildpack/util.py
+++ b/buildpack/util.py
@@ -132,7 +132,7 @@ def download_and_unpack(
                 ("mono-", "jdk-", "jre-", "AdoptOpenJDK-")
             ):
                 unpack_cmd.extend(("--strip", "1"))
-        elif file_name.endswith(".zip"):
+        else:
             unpack_cmd = ["unzip", cached_location, "-d", destination]
 
         if unpack_cmd:


### PR DESCRIPTION
The primary trigger for this PR is to repair a bug introduced in 837b0dccc78904edfb4dcd3a5ce95b6bae86704a which essentially reverted 13bec1c8f8ffb9afef5e42393d34f4ec9136f24b

Based on feedback from the ASML team we have also improved the Dynatrace integration to not block application startup if the dynatrace plugin cannot be set up.