### PR TITLE
Added option to use a custom NGINX binary

### DIFF
--- a/buildpack/nginx.py
+++ b/buildpack/nginx.py
@@ -175,10 +175,17 @@ def get_http_headers():
     return result
 
 
+def get_nginx_bin_path():
+    nginx_bin_path = os.environ.get(
+        "NGINX_CUSTOM_BIN_PATH", "nginx/sbin/nginx"
+    )
+    return nginx_bin_path
+
+
 def run():
     nginx_process = subprocess.Popen(
         [
-            "nginx/sbin/nginx",
+            get_nginx_bin_path(),
             "-p",
             "nginx",
             "-c",

--- a/tests/unit/test_nginx_path.py
+++ b/tests/unit/test_nginx_path.py
@@ -1,0 +1,17 @@
+import json
+import os
+import unittest
+
+from buildpack import nginx
+
+
+class TestCaseNginxBinPath(unittest.TestCase):
+    def test_default_nginx_bin_path(self):
+        del os.environ["NGINX_CUSTOM_BIN_PATH"]
+        nginx_bin_path = nginx.get_nginx_bin_path()
+        self.assertEquals("nginx/sbin/nginx", nginx_bin_path)
+
+    def test_custom_nginx_bin_path(self):
+        os.environ["NGINX_CUSTOM_BIN_PATH"] = "/usr/sbin/nginx"
+        nginx_bin_path = nginx.get_nginx_bin_path()
+        self.assertEquals("/usr/sbin/nginx", nginx_bin_path)


### PR DESCRIPTION
If the `NGINX_CUSTOM_BIN_PATH` environment variable is specified, use it to find the `nginx` binary instead of `nginx` that's included with the Buildpack.

Setting a custom `NGINX_CUSTOM_BIN_PATH` (e.g. `/usr/sbin/nginx`) will allow to use NGINX from the base OS.