### PR TITLE
Skip nginx download if NGINX_CUSTOM_BIN_PATH is specified

### DIFF
--- a/buildpack/nginx.py
+++ b/buildpack/nginx.py
@@ -53,6 +53,11 @@ def _is_samesite_cookie_workaround_enabled(mx_version):
         return False
 
 
+def is_custom_nginx():
+    if "NGINX_CUSTOM_BIN_PATH" in os.environ:
+        return True
+
+
 def stage(buildpack_path, build_path, cache_path):
     logging.debug("Staging nginx...")
     shutil.copytree(
@@ -60,13 +65,19 @@ def stage(buildpack_path, build_path, cache_path):
         os.path.join(build_path, "nginx"),
     )
 
-    util.download_and_unpack(
-        util.get_blobstore_url(
-            "/mx-buildpack/nginx_1.19.1_linux_x64_cflinuxfs3_b5af01b0.tgz"
-        ),
-        os.path.join(build_path, "nginx"),
-        cache_dir=cache_path,
-    )
+    if not is_custom_nginx():
+        logging.debug("Downloading nginx...")
+        util.download_and_unpack(
+            util.get_blobstore_url(
+                "/mx-buildpack/nginx_1.19.1_linux_x64_cflinuxfs3_b5af01b0.tgz"
+            ),
+            os.path.join(build_path, "nginx"),
+            cache_dir=cache_path,
+        )
+    else:
+        logging.debug(
+            "Custom nginx path provided, nginx will not be downloaded"
+        )
 
 
 def configure(m2ee):

--- a/tests/unit/test_nginx_path.py
+++ b/tests/unit/test_nginx_path.py
@@ -9,9 +9,13 @@ class TestCaseNginxBinPath(unittest.TestCase):
     def test_default_nginx_bin_path(self):
         del os.environ["NGINX_CUSTOM_BIN_PATH"]
         nginx_bin_path = nginx.get_nginx_bin_path()
+        is_custom_nginx = nginx.is_custom_nginx()
         self.assertEquals("nginx/sbin/nginx", nginx_bin_path)
+        self.assertFalse(is_custom_nginx)
 
     def test_custom_nginx_bin_path(self):
         os.environ["NGINX_CUSTOM_BIN_PATH"] = "/usr/sbin/nginx"
         nginx_bin_path = nginx.get_nginx_bin_path()
+        is_custom_nginx = nginx.is_custom_nginx()
         self.assertEquals("/usr/sbin/nginx", nginx_bin_path)
+        self.assertTrue(is_custom_nginx)


### PR DESCRIPTION
Follow-up for https://github.com/mendix/cf-mendix-buildpack/pull/395:
If the `NGINX_CUSTOM_BIN_PATH` environment variable is set, do not download nginx from CDN.