### PR TITLE
Redact PostgreSQL Credentials in Datadog Logs

### DIFF
--- a/buildpack/datadog.py
+++ b/buildpack/datadog.py
@@ -345,32 +345,43 @@ def _set_up_environment():
 
 
 def _get_logging_config():
-    config = [
+    config = {
+        "type": "tcp",
+        "port": str(LOGS_PORT),
+        "source": "mendix",
+        "service": get_service(),
+    }
+
+    # Standard rules for e.g. credential redaction
+    rules = [
         {
-            "type": "tcp",
-            "port": str(LOGS_PORT),
-            "source": "mendix",
-            "service": get_service(),
+            "type": "mask_sequences",
+            "name": "postgres_credentials",
+            "pattern": r"\'jdbc:postgresql://(.*)\'",
+            "replace_placeholder": "[SECRET REDACTED]",
         }
     ]
 
+    # Optional redaction rules; can be toggled with an environment variable
     if _is_logs_redaction_enabled():
         logging.info(
             "Datadog logs redaction enabled, all email addresses will be redacted"
         )
-        log_processing_rules = {
-            "log_processing_rules": [
-                {
-                    "type": "mask_sequences",
-                    "name": "RFC_5322_email",
-                    "pattern": r"""(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])""",
-                    "replace_placeholder": "[EMAIL REDACTED]",
-                }
-            ]
-        }
-        config[0] = {**config[0], **log_processing_rules}
 
-    return config
+        rules.append(
+            {
+                "type": "mask_sequences",
+                "name": "RFC_5322_email",
+                "pattern": r"""(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])""",
+                "replace_placeholder": "[EMAIL REDACTED]",
+            }
+        )
+
+    log_processing_rules = {"log_processing_rules": rules}
+
+    config = {**config, **log_processing_rules}
+
+    return [config]
 
 
 def update_config(m2ee, extra_jmx_instance_config=None, jmx_config_files=[]):


### PR DESCRIPTION
This PR automatically redacts RDS / PostgreSQL credentials from Mendix runtime logs before they are sent to Datadog.
The associated redaction rule is always enabled.