### PR TITLE
Improve Python bootstrap script

### DIFF
--- a/bin/bootstrap-python
+++ b/bin/bootstrap-python
@@ -21,7 +21,6 @@ fi
 
 PIP_CMD="python3 ${PIP_WHL_PATH}/pip"
 PIP_WHEELDIR="${CACHE_PATH}/pip/wheels"
-PIP_WORKDIR="${CACHE_PATH}/pip/build"
 # Set the correct Python site-packages directory to install to
 SITE_PACKAGES_PATH="${BUILD_PATH}/$(python3 -m site --user-site | cut -d '/' -f4-)"
 
@@ -30,7 +29,7 @@ mkdir -p $PIP_WHEELDIR;
 cp -rf $WHEELS_PATH/* $PIP_WHEELDIR/;
 
 echo " ---> Bootstrapping pip and setuptools..."
-$PIP_CMD install --user --no-warn-script-location --no-index --find-links=$PIP_WHEELDIR --build=$PIP_WORKDIR pip setuptools
+$PIP_CMD install --user --no-warn-script-location --no-index --find-links=$PIP_WHEELDIR pip setuptools
 
 echo " ---> Downloading Python dependencies if necessary..."
 if [[ $(ls -1q $PIP_WHEELDIR/*.whl | wc -l) = 2 ]]
@@ -42,5 +41,5 @@ else
 fi
 
 echo " ---> Installing Python dependencies to ${SITE_PACKAGES_PATH}..."
-$PIP_CMD install --target $SITE_PACKAGES_PATH --no-warn-script-location --no-index --find-links=$PIP_WHEELDIR --build=$PIP_WORKDIR -r $REQUIREMENTS_PATH
+$PIP_CMD install --target $SITE_PACKAGES_PATH --no-warn-script-location --no-index --find-links=$PIP_WHEELDIR -r $REQUIREMENTS_PATH
 echo " ---> Finished installing Python dependencies"

--- a/bin/bootstrap-python
+++ b/bin/bootstrap-python
@@ -13,9 +13,15 @@ WHEELS_PATH="${BUILDPACK_PATH}/vendor/wheels"
 PIP_WHL_PATH=$(ls $WHEELS_PATH/pip*.whl | head -n1)
 SETUPTOOLS_WHL_PATH=$(ls $WHEELS_PATH/setuptools*.whl | head -n1)
 
+PIP_VERBOSITY_FLAGS=""
+if [[ -z $BUILDPACK_XTRACE ]] || [[ $BUILDPACK_XTRACE == "false" ]]
+then
+    PIP_VERBOSITY_FLAGS="--quiet"
+fi
+
 if [[ -z $PIP_WHL_PATH ]] || [[ -z $(ls $WHEELS_PATH/setuptools*.whl | head -n1) ]]
 then
-    echo "pip or setuptools wheels not present in buildpack, cannot stage app"
+    echo "ERROR: pip or setuptools wheels not present in buildpack, cannot stage app"
     exit 1
 fi
 
@@ -24,22 +30,22 @@ PIP_WHEELDIR="${CACHE_PATH}/pip/wheels"
 # Set the correct Python site-packages directory to install to
 SITE_PACKAGES_PATH="${BUILD_PATH}/$(python3 -m site --user-site | cut -d '/' -f4-)"
 
-echo " ---> Copying included wheels to cache...";
+echo " ---> Copying bundled Python dependencies to cache...";
 mkdir -p $PIP_WHEELDIR;
 cp -rf $WHEELS_PATH/* $PIP_WHEELDIR/;
 
 echo " ---> Bootstrapping pip and setuptools..."
-$PIP_CMD install --user --no-warn-script-location --no-index --find-links=$PIP_WHEELDIR pip setuptools
+$PIP_CMD install $PIP_VERBOSITY_FLAGS --user --no-warn-script-location --no-index --find-links=$PIP_WHEELDIR pip setuptools
 
-echo " ---> Downloading Python dependencies if necessary..."
 if [[ $(ls -1q $PIP_WHEELDIR/*.whl | wc -l) = 2 ]]
 then
-    echo " ---> Downloading Python dependencies as wheels...";
-    $PIP_CMD download -r $REQUIREMENTS_PATH --prefer-binary -d $PIP_WHEELDIR;
+    echo " ---> Downloading Python dependencies...";
+    $PIP_CMD download $PIP_VERBOSITY_FLAGS -r $REQUIREMENTS_PATH --prefer-binary -d $PIP_WHEELDIR;
 else
-    echo "Wheelhouse contains more than two files, assuming that all Python dependencies have been packaged";
+    # Assume that more than two wheels present implies that dependencies are bundled
+    echo " ---> Using bundled Python dependencies";
 fi
 
 echo " ---> Installing Python dependencies to ${SITE_PACKAGES_PATH}..."
-$PIP_CMD install --target $SITE_PACKAGES_PATH --no-warn-script-location --no-index --find-links=$PIP_WHEELDIR -r $REQUIREMENTS_PATH
+$PIP_CMD install $PIP_VERBOSITY_FLAGS --target $SITE_PACKAGES_PATH --no-warn-script-location --no-index --find-links=$PIP_WHEELDIR -r $REQUIREMENTS_PATH
 echo " ---> Finished installing Python dependencies"


### PR DESCRIPTION
This PR includes the following:

- Removed the `pip` `-b` deprecation warning
- Made the Python bootstrapping process output verbosity dependent on the `BUILDPACK_XTRACE` environment variable