### PR TITLE
Add offline.html to 503 error handling

### DIFF
--- a/etc/nginx/conf/nginx.conf.j2
+++ b/etc/nginx/conf/nginx.conf.j2
@@ -172,7 +172,7 @@ http {
             return 503;
         }
         location @503-custom {
-            try_files /error_page/503.html =503;
+            try_files /error_page/offline.html =503;
         }
     }
 }


### PR DESCRIPTION
This PR re-adds `offline.html` to the 503 error handling flow.