### PR TITLE
Various Datadog improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ Additionally, we configure the following Datadog environment variables for you:
 | `DD_VERSION` | `<model_version>` | Yes | Reserved tag. Set to the value of the `version` tag. Defaults to the Mendix model version of the application. |
 | `DD_TAGS` | `tag1:value1,...:...` | Yes | Global tags for Datadog Agent(s). Derived from the runtime settings in Mendix Public Cloud or the `TAGS` environment variable. |
 | `DD_TRACE_ENABLED` | `false` | Yes | Enables Datadog APM and the Trace Agent(s). **Enabling Datadog APM is experimental and enables tracing via the [Datadog Java Trace Agent](https://docs.datadoghq.com/tracing/setup/java/) tracing functionality.** |
+| `DD_PROFILING_ENABLED` | `false` | Yes | Enables Datadog APM and the Trace Agent(s). **Enabling Datadog Profiling is experimental and can only be enabled for Mendix 7.23.1 and up, and requires tracing to be enabled.** |
 | `DD_JMXFETCH_ENABLED` | `true` | No | Enables Datadog Java Trace Agent JMX metrics fetching |
 | `DD_SERVICE_MAPPING` | `<database>:<app>.db` | No | Links your database to your app in Datadog APM |
 | `DD_LOGS_ENABLED` | `true` | No | Enables sending your application logs directly to Datadog |

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ The latest [release](https://github.com/mendix/cf-mendix-buildpack/releases/late
 
 | Mendix Version | Minimal Buildpack Release |
 | ----           | ----                      |
-| `8.x`          | `v3.4.0`                  |
-| `7.23.x`       | `v3.1.0`                  |
-| `6.x`, `7.x`   | `v1.0`                    |
+| `8.x` | `v3.4.0` |
+| `7.23.x` | `v3.1.0` |
+| `6.x` , `7.x` | `v1.0` |
 
 The buildpack is heavily tied to the Mendix Public Cloud, but can be used independently.
 Release notes are available for the [buildpack](https://github.com/mendix/cf-mendix-buildpack/releases/), [Mendix itself](https://docs.mendix.com/releasenotes/studio-pro/) and the [Mendix Public Cloud](https://docs.mendix.com/releasenotes/developer-portal/deployment).
@@ -124,6 +124,7 @@ cf restart <YOUR_APP>
 The scheduled events can be configured using environment variable `SCHEDULED_EVENTS` .
 
 Possible values are `ALL` , `NONE` or a comma separated list of the scheduled events that you would like to enable. For example: `ModuleA.ScheduledEvent,ModuleB.OtherScheduledEvent`
+
 When scaling to multiple instances, the scheduled events that are enabled via the settings above will only be executed on instance `0` . The other instances will not execute scheduled events at all.
 
 ### Configuring External Filestore
@@ -228,7 +229,7 @@ Google Chrome will - at a certain moment - [enforce cookie security](https://www
 
 The buildpack can inject these two properties into all cookies for affected runtime versions.
 
-This workaround is disabled by default. If your application supports injecting these cookies, you can choose to enable cookie header injection by setting the `SAMESITE_COOKIE_PRE_MX812` environment variable to `true`.
+This workaround is disabled by default. If your application supports injecting these cookies, you can choose to enable cookie header injection by setting the `SAMESITE_COOKIE_PRE_MX812` environment variable to `true` .
 
 ### Horizontal Scaling
 
@@ -264,6 +265,7 @@ NOTE: The previously documented setting `CLUSTER_ENABLED` and the REDIS related 
 If you are running Cloud Foundry without a connection to the Internet, you should specify an on-premises web server that hosts Mendix Runtime files and other buildpack resources. You can set the endpoint with the following environment variable:
 
  `BLOBSTORE: https://my-intranet-webserver.my-company.com/mendix/`
+
 The preferred way to set up this on-premises web server is as a transparent proxy to `https://cdn.mendix.com/` . This prevents manual work by system administrators every time a new Mendix version is released.
 
 Alternatively you can make the required mendix runtime files `mendix-VERSION.tar.gz` available under `BLOBSTORE/runtime/` . The original files can be downloaded from `https://cdn.mendix.com/` . You should also make the Java version available on:
@@ -412,22 +414,23 @@ Please note that application metric collection **requires Mendix 7.14 or higher*
 For correlation purposes, we set the Datadog `service` for you to match your **application name**. This name is derived in the following order:
 
 1. Your Mendix `service:` tag if you have set this in the runtime settings or `TAGS` environment variable.<br/>*Format:* `["service:myfirstapp", "tag2:value2", ...]`.
-2. Your Mendix `app:` tag if you have set this in the runtime settings or `TAGS` environment variable.<br/>*Example:* for `app:myfirstapp` , `service` will be set to `myfirstapp`.
-3. The first part of the Cloud Foundry route URI configured for your application, without numeric characters.<br/>*Example:* for a route URI `myfirstapp1000-test.example.com` , `service` will be set to `myfirstapp` .
+2. Your Mendix `app:` tag if you have set this in the runtime settings or `TAGS` environment variable.<br/>*Example:* for `app:myfirstapp` ,  `service` will be set to `myfirstapp`.
+3. The first part of the Cloud Foundry route URI configured for your application, without numeric characters.<br/>*Example:* for a route URI `myfirstapp1000-test.example.com` ,  `service` will be set to `myfirstapp` .
 
 Additionally, we configure the following Datadog environment variables for you:
 
 | Environment Variable | Value | Can Be Overridden? | Description |
 |-|-|-|-|
-| `DD_HOSTNAME` | `<app>-<env>.mendixcloud.com-<instance>` | No | Human-readable host name for your application |
-| `DD_ENV` | `<env>` | Yes | Reserved tag. Set to the value of the `env` tag. Defaults to `none`.
-| `DD_SERVICE` | `<app>` | Yes | Reserved tag. Set as as described before. Is only set when `DD_TRACE_ENABLED` is set to `true`. |
+| `DD_HOSTNAME` | `<app>-<env>.mendixcloud.com<-instance>` | No | Human-readable host name for your application |
+| `DD_ENV` | `<env>` | Yes | Reserved tag. Set to the value of the `env` tag. Defaults to `none` .
+| `DD_SERVICE` | `<app>` | Yes | Reserved tag. Set as as described before. Is only set when `DD_TRACE_ENABLED` is set to `true` . |
 | `DD_VERSION` | `<model_version>` | Yes | Reserved tag. Set to the value of the `version` tag. Defaults to the Mendix model version of the application. |
 | `DD_TAGS` | `tag1:value1,...:...` | Yes | Global tags for Datadog Agent(s). Derived from the runtime settings in Mendix Public Cloud or the `TAGS` environment variable. |
 | `DD_TRACE_ENABLED` | `false` | Yes | Enables Datadog APM and the Trace Agent(s). **Enabling Datadog APM is experimental and enables tracing via the [Datadog Java Trace Agent](https://docs.datadoghq.com/tracing/setup/java/) tracing functionality.** |
 | `DD_JMXFETCH_ENABLED` | `true` | No | Enables Datadog Java Trace Agent JMX metrics fetching |
 | `DD_SERVICE_MAPPING` | `<database>:<app>.db` | No | Links your database to your app in Datadog APM |
 | `DD_LOGS_ENABLED` | `true` | No | Enables sending your application logs directly to Datadog |
+| `DD_CHECKS_ENABLED` | `false` | Yes | Enables system metrics. These are disabled by default, as the metrics might be host metrics instead of container metrics. |
 
 Other environment variables can be set as per the [Datadog Agent documentation](https://docs.datadoghq.com/agent/).
 
@@ -435,9 +438,9 @@ Other environment variables can be set as per the [Datadog Agent documentation](
 
 Telegraf [does not support (Datadog) metric types correctly yet](https://github.com/influxdata/telegraf/issues/6822) (e.g. rate, counter, gauge). This means that all database metrics are currently pushed to Datadog as a gauge.
 
-The most important metrics (`before_xid_wraparound`, `connections`, `database_size`, `db.count`, `locks`, `max_connections`, `percent_usage_connections`, `table.count`, `deadlocks`) are gauges and are compatible with the Datadog PostgreSQL integration and associated dashboards.
+The most important metrics ( `before_xid_wraparound` , `connections` , `database_size` , `db.count` , `locks` , `max_connections` , `percent_usage_connections` , `table.count` , `deadlocks` ) are gauges and are compatible with the Datadog PostgreSQL integration and associated dashboards.
 
-*If you do require the additional rate and counter metrics, there is a workaround available.* First, set the `DATADOG_DATABASE_RATE_COUNT_METRICS` environment variable to `true`. After that variable is enabled, the rate and counter metrics are suffixed by either `_count` or `_rate` to prevent collisions with the official Datadog metrics. In the Datadog UI, the [metric type and unit can be changed](https://docs.datadoghq.com/developers/metrics/type_modifiers/?tab=count#modify-a-metrics-type-within-datadog) to reflect this. We also set a helpful `interval` tag (`10s`) which can be used here. Additionally, gauge metrics can be [rolled up in Datadog dashboards](https://docs.datadoghq.com/dashboards/functions/rollup/). The correct type and unit for other submitted metrics can be found [here](https://github.com/DataDog/integrations-core/blob/master/postgres/metadata.csv).
+*If you do require the additional rate and counter metrics, there is a workaround available.* First, set the `DATADOG_DATABASE_RATE_COUNT_METRICS` environment variable to `true` . After that variable is enabled, the rate and counter metrics are suffixed by either `_count` or `_rate` to prevent collisions with the official Datadog metrics. In the Datadog UI, the [metric type and unit can be changed](https://docs.datadoghq.com/developers/metrics/type_modifiers/?tab=count#modify-a-metrics-type-within-datadog) to reflect this. We also set a helpful `interval` tag ( `10s` ) which can be used here. Additionally, gauge metrics can be [rolled up in Datadog dashboards](https://docs.datadoghq.com/dashboards/functions/rollup/). The correct type and unit for other submitted metrics can be found [here](https://github.com/DataDog/integrations-core/blob/master/postgres/metadata.csv).
 
 ### Dynatrace
 
@@ -492,6 +495,7 @@ You can see the available Log Nodes in your application in the Mendix Modeler. T
 * `INFO`
 * `DEBUG`
 * `TRACE`
+
 Example:
 
 ``` shell
@@ -516,7 +520,7 @@ You can enable the Mendix Debugger by setting a `DEBUGGER_PASSWORD` environment 
 
 We recommend "pinning to" - using a specific [release](https://github.com/mendix/cf-mendix-buildpack/releases) of - the buildpack. This will prevent you from being affected by bugs that are inadvertently introduced, but you will need to set up a procedure to regularly move to new versions of the buildpack.
 
-To push with a specific release of the buildpack, replace `<RELEASE>` in the buildpack URL below in your `cf push` command with the release you want to pin to, e.g. `v4.11.0`:
+To push with a specific release of the buildpack, replace `<RELEASE>` in the buildpack URL below in your `cf push` command with the release you want to pin to, e.g. `v4.11.0` :
 
 ``` shell
 cf push <YOUR_APP> -b https://github.com/mendix/cf-mendix-buildpack/releases/download/<RELEASE>/cf-mendix-buildpack.zip -p <YOUR_MDA>.mda -t 180
@@ -584,8 +588,8 @@ When it is desired to push MPKs produced by Mendix Studio Pro 6.x to containers 
 
 # Developing and Contributing
 
-Please see [`DEVELOPING.md`](DEVELOPING.md) and [`CONTRIBUTING.md`](CONTRIBUTING.md).
+Please see [ `DEVELOPING.md` ](DEVELOPING.md) and [ `CONTRIBUTING.md` ](CONTRIBUTING.md).
 
 # License
 
-This project is licensed under the Apache License v2 (for details, see the [`LICENSE`](LICENSE) file).
+This project is licensed under the Apache License v2 (for details, see the [ `LICENSE` ](LICENSE) file).

--- a/README.md
+++ b/README.md
@@ -420,12 +420,14 @@ Additionally, we configure the following Datadog environment variables for you:
 | Environment Variable | Value | Can Be Overridden? | Description |
 |-|-|-|-|
 | `DD_HOSTNAME` | `<app>-<env>.mendixcloud.com-<instance>` | No | Human-readable host name for your application |
+| `DD_ENV` | `<env>` | Yes | Reserved tag. Set to the value of the `env` tag. Defaults to `none`.
+| `DD_SERVICE` | `<app>` | Yes | Reserved tag. Set as as described before. Is only set when `DD_TRACE_ENABLED` is set to `true`. |
+| `DD_VERSION` | `<model_version>` | Yes | Reserved tag. Set to the value of the `version` tag. Defaults to the Mendix model version of the application. |
+| `DD_TAGS` | `tag1:value1,...:...` | Yes | Global tags for Datadog Agent(s). Derived from the runtime settings in Mendix Public Cloud or the `TAGS` environment variable. |
+| `DD_TRACE_ENABLED` | `false` | Yes | Enables Datadog APM and the Trace Agent(s). **Enabling Datadog APM is experimental and enables tracing via the [Datadog Java Trace Agent](https://docs.datadoghq.com/tracing/setup/java/) tracing functionality.** |
 | `DD_JMXFETCH_ENABLED` | `true` | No | Enables Datadog Java Trace Agent JMX metrics fetching |
-| `DD_LOGS_ENABLED` | `true` | No | Enables sending your application logs directly to Datadog |
 | `DD_SERVICE_MAPPING` | `<database>:<app>.db` | No | Links your database to your app in Datadog APM |
-| `DD_SERVICE_NAME` | `<app>` | No | Defaults to your application name as described before. Is only set when `DD_TRACE_ENABLED` is set to `true` . |
-| `DD_TAGS` | `tag1:value1,...:...` | No | Derived from the runtime settings in Mendix Public Cloud or the `TAGS` environment variable |
-| `DD_TRACE_ENABLED` | `false` | Yes | Disables Datadog APM by default. **Enabling Datadog APM is experimental and enables tracing via the [Datadog Java Trace Agent](https://docs.datadoghq.com/tracing/setup/java/) tracing functionality.** |
+| `DD_LOGS_ENABLED` | `true` | No | Enables sending your application logs directly to Datadog |
 
 Other environment variables can be set as per the [Datadog Agent documentation](https://docs.datadoghq.com/agent/).
 

--- a/buildpack/datadog.py
+++ b/buildpack/datadog.py
@@ -110,6 +110,12 @@ def is_database_diskstorage_metric_enabled():
     )
 
 
+# Toggles the system checks. Note that these may not mean anything as they
+# might show the host metrics instead of the container metrics.
+def _is_checks_enabled():
+    return strtobool(os.environ.get("DD_ENABLE_CHECKS", "false"))
+
+
 def _is_installed():
     return os.path.exists(_get_agent_dir())
 
@@ -373,7 +379,7 @@ def _set_up_environment(model_version):
     e["DATADOG_DIR"] = str(_get_agent_dir())
     e["RUN_AGENT"] = "true"
     e["DD_LOGS_ENABLED"] = "true"
-    e["DD_ENABLE_CHECKS"] = "false"
+    e["DD_ENABLE_CHECKS"] = str(bool(_is_checks_enabled())).lower()
     e["LOGS_CONFIG"] = json.dumps(_get_logging_config())
 
     return e
@@ -516,7 +522,7 @@ def _patch_run_datadog_script(script_dir):
     # This works great in multi-buildpack scenarios where the environment variables
     # are set while deploying the application.
     #
-    # This is not the case here, and we cannot use the official method since we're 
+    # This is not the case here, and we cannot use the official method since we're
     # setting Datadog environment variables at start, and the agent runs before start.
     # Also, the stop_datadog call assumes a different PID than present, causing a kill
     # call to fail. This applies to all Datadog buildpack versions > 4.20.0.
@@ -534,7 +540,6 @@ def _patch_run_datadog_script(script_dir):
                 f.write(line)
         f.truncate()
 
-    
 
 def stage(buildpack_path, build_path, cache_path):
     if not is_enabled():

--- a/buildpack/start.py
+++ b/buildpack/start.py
@@ -107,8 +107,11 @@ if __name__ == "__main__":
         ) = databroker_processes.get_datadog_config(
             datadog._get_user_checks_dir()
         )
+
+        model_version = runtime.get_model_version(os.path.abspath("."))
         datadog.update_config(
             m2ee,
+            model_version=model_version,
             extra_jmx_instance_config=databroker_jmx_instance_cfg,
             jmx_config_files=databroker_jmx_config_files,
         )
@@ -145,7 +148,7 @@ if __name__ == "__main__":
 
         # Start components and runtime
         telegraf.run()
-        datadog.run()
+        datadog.run(model_version)
         metering.run()
         nginx.run()
         runtime.run(m2ee)

--- a/buildpack/start.py
+++ b/buildpack/start.py
@@ -86,14 +86,15 @@ if __name__ == "__main__":
         # Initialize the runtime
         m2ee = runtime.setup(util.get_vcap_data())
 
+        # Get versions
+        runtime_version = runtime.get_version(os.path.abspath("."))
+        java_version = runtime.get_java_version(runtime_version)["version"]
+        model_version = runtime.get_model_version(os.path.abspath("."))
+
         # Update runtime configuration based on component configuration
-        java_version = runtime.get_java_version(
-            m2ee.config.get_runtime_version()
-        )["version"]
         java.update_config(
             m2ee.config._conf["m2ee"], util.get_vcap_data(), java_version
         )
-
         newrelic.update_config(m2ee, util.get_vcap_data()["application_name"])
         appdynamics.update_config(
             m2ee, util.get_vcap_data()["application_name"]
@@ -107,11 +108,10 @@ if __name__ == "__main__":
         ) = databroker_processes.get_datadog_config(
             datadog._get_user_checks_dir()
         )
-
-        model_version = runtime.get_model_version(os.path.abspath("."))
         datadog.update_config(
             m2ee,
             model_version=model_version,
+            runtime_version=runtime_version,
             extra_jmx_instance_config=databroker_jmx_instance_cfg,
             jmx_config_files=databroker_jmx_config_files,
         )
@@ -148,7 +148,7 @@ if __name__ == "__main__":
 
         # Start components and runtime
         telegraf.run()
-        datadog.run(model_version)
+        datadog.run(model_version, runtime_version)
         metering.run()
         nginx.run()
         runtime.run(m2ee)

--- a/buildpack/telegraf.py
+++ b/buildpack/telegraf.py
@@ -148,7 +148,7 @@ def update_config(m2ee, app_name):
     tags = util.get_tags()
     if datadog.is_enabled() and "service" not in tags:
         # app and / or service tag not set
-        tags["service"] = datadog.get_service()
+        tags["service"] = datadog.get_service_tag()
 
     with open(template_path, "r") as file_:
         template = Template(file_.read(), trim_blocks=True, lstrip_blocks=True)

--- a/buildpack/util.py
+++ b/buildpack/util.py
@@ -39,8 +39,12 @@ def get_domain():
     return get_vcap_data()["application_uris"][0].split("/")[0]
 
 
-def get_hostname():
-    return get_domain() + "-" + os.getenv("CF_INSTANCE_INDEX", "")
+def get_hostname(add_instance_index=True):
+    result = get_domain()
+    cf_instance_index = os.getenv("CF_INSTANCE_INDEX")
+    if cf_instance_index and add_instance_index:
+        result += "-{}".format(cf_instance_index)
+    return result
 
 
 def get_app_from_domain():

--- a/tests/integration/test_datadog.py
+++ b/tests/integration/test_datadog.py
@@ -42,7 +42,7 @@ class TestCaseDeployWithDatadog(basetest.BaseTestWithPostgreSQL):
 
     def _test_dd_tags(self):
         self.assert_string_in_recent_logs(
-            "'DD_TAGS': 'app:testapp,env:dev,service:testapp'"
+            "'DD_TAGS': 'app:testapp,env:dev,service:testapp,version:"
         )
 
     def _test_datadog(self, mda_file):

--- a/tests/integration/test_datadog.py
+++ b/tests/integration/test_datadog.py
@@ -15,6 +15,7 @@ class TestCaseDeployWithDatadog(basetest.BaseTestWithPostgreSQL):
                 ),
                 "DD_TRACE_ENABLED": "true",
                 # "DD_TRACE_DEBUG": "true",
+                "DD_PROFILING_ENABLED": "true",
                 "DATADOG_DATABASE_DISKSTORAGE_METRIC": "true",
                 "DATABASE_DISKSTORAGE": 10.0,
                 "DATADOG_DATABASE_RATE_COUNT_METRICS": "true",

--- a/tests/unit/test_datadog.py
+++ b/tests/unit/test_datadog.py
@@ -18,4 +18,4 @@ class TestCaseDatadogUtilFunctions(unittest.TestCase):
         for (tags, outcome) in tags_cases:
             with self.subTest(tags=tags, outcome=outcome):
                 os.environ["TAGS"] = json.dumps(tags)
-                self.assertEqual(datadog.get_service(), outcome)
+                self.assertEqual(datadog.get_service_tag(), outcome)


### PR DESCRIPTION
This PR includes the following:
- Adds the `version` tag
- Adds explicit environment variables and Java options for the reserved `env`, `service` and `version` tags
- Adds a toggle for enabling system checks (may provide host metrics instead of container metrics)
- Adds a toggle for enabling profiling (experimental)
- Bumps the Datadog Agent version to `7.26` (through Datadog CF buildpack `4.21.0`) and the Datadog Java Trace agent to `0.78.2`