### PR TITLE
Update version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@
 
 This document contains general information on the Mendix Cloud Foundry Buildpack.
 
-The latest [release](https://github.com/mendix/cf-mendix-buildpack/releases/latest) supports Mendix versions 6, 7 and 8. See the table which buildpack release introduced support for a Mendix version. [This section](#buildpack-releases-and-version-pinning) describes how to use a specific release.
+The latest [release](https://github.com/mendix/cf-mendix-buildpack/releases/latest) supports Mendix versions 7 (LTS), 8 (LTS) and 9. See the table which buildpack release introduced support for a Mendix version, and in which release versions [are end-of-support](https://docs.mendix.com/releasenotes/studio-pro/lts-mts). [This section](#buildpack-releases-and-version-pinning) describes how to use a specific release.
 
-| Mendix Version | Minimal Buildpack Release |
-| ----           | ----                      |
-| `8.x` | `v3.4.0` |
-| `7.23.x` | `v3.1.0` |
-| `6.x` , `7.x` | `v1.0` |
+| Mendix Version | Supported | End-of-Support |
+| ---- | ---- | ---- |
+| `9.x` | `v4.16.0` | - |
+| `8.18.x` ([LTS](https://docs.mendix.com/releasenotes/studio-pro/lts-mts)) | `v3.4.0` | - |
+| `8 < 8.x` | `v3.4.0` | `v4.16.0` |
+| `7.23.x` ([LTS](https://docs.mendix.com/releasenotes/studio-pro/lts-mts)) | `v3.1.0` | - |
+| `6.x` , `7 < 7.23.x` | `v1.0` | `v4.16.0` |
 
 The buildpack is heavily tied to the Mendix Public Cloud, but can be used independently.
 Release notes are available for the [buildpack](https://github.com/mendix/cf-mendix-buildpack/releases/), [Mendix itself](https://docs.mendix.com/releasenotes/studio-pro/) and the [Mendix Public Cloud](https://docs.mendix.com/releasenotes/developer-portal/deployment).

--- a/buildpack/runtime.py
+++ b/buildpack/runtime.py
@@ -32,11 +32,21 @@ if len(handlers) > 2:
 logging.getLogger("m2ee").propagate = False
 
 
-def check_deprecation(version):
-    if version >= MXVersion("5.0.0") and version < MXVersion("6.0.0"):
+def is_version_supported(version):
+    if version < MXVersion("6.0.0"):
         return False
 
     return True
+
+
+def is_version_end_of_support(version):
+    # LTS versions: https://docs.mendix.com/releasenotes/studio-pro/lts-mts
+    if version >= MXVersion("6.0.0") and version < MXVersion("7.23"):
+        return True
+    if version >= MXVersion("8.0.0") and version < MXVersion("8.18"):
+        return True
+
+    return False
 
 
 def _get_runtime_url(blobstore, build_path):

--- a/buildpack/stage.py
+++ b/buildpack/stage.py
@@ -56,16 +56,26 @@ def preflight_check(version):
 
     stack = os.getenv("CF_STACK")
     logging.info(
-        "Preflight check on Mendix runtime version [%s] and stack [%s]...",
+        "Preflight check on Mendix version [%s] and stack [%s]...",
         version,
         stack,
     )
 
     if not stack in SUPPORTED_STACKS:
-        raise NotImplementedError("Stack [{}] is not supported".format(stack))
-    if not runtime.check_deprecation(version):
         raise NotImplementedError(
-            "Mendix runtime version [{}] is not supported".format(version)
+            "Stack [{}] is not supported by this buildpack".format(stack)
+        )
+    if not runtime.is_version_supported(version):
+        raise NotImplementedError(
+            "Mendix version [{}] is not supported by this buildpack".format(
+                version
+            )
+        )
+    if runtime.is_version_end_of_support(version):
+        logging.warning(
+            "Mendix version [{}] is end-of-support. Please upgrade to a supported Mendix version (https://docs.mendix.com/releasenotes/studio-pro/lts-mts).".format(
+                version
+            )
         )
     logging.info("Preflight check completed")
 

--- a/tests/integration/test_deprecations.py
+++ b/tests/integration/test_deprecations.py
@@ -1,11 +1,21 @@
 from tests.integration import basetest
 
 
-class TestCaseDeprecationMx5(basetest.BaseTest):
-    def test_mx5_mpk(self):
-        with self.assertRaises(RuntimeError):
-            self.stage_container("mx5.3.2_app.mpk")
-
-    def test_mx5_mda(self):
+class TestCaseMxNotSupported(basetest.BaseTest):
+    def test_mx5_notsupported(self):
         with self.assertRaises(RuntimeError):
             self.stage_container("mx5.3.2_app.mda")
+
+
+class TestCaseMxEndOfSupport(basetest.BaseTest):
+    def _test_end_of_support(self, application):
+        assert "] is end-of-support" in self.stage_container(application)[0]
+
+    def test_mx6_end_of_support(self):
+        self._test_end_of_support("sample-6.2.0.mda")
+
+    def test_mx7_end_of_support(self):
+        self._test_end_of_support("BuildpackTestApp-mx-7-16.mda")
+
+    def test_mx8_end_of_support(self):
+        self._test_end_of_support("Mendix8.1.1.58432_StarterApp.mda")


### PR DESCRIPTION
This PR changes the following:
- Explicitly lists Mendix 9 support
- Deprecates [non-LTS / non-MTS](https://docs.mendix.com/releasenotes/studio-pro/lts-mts) runtime versions