### PR TITLE
Storage S3 STS support for Mendix 7/8

### DIFF
--- a/buildpack/runtime_components/storage.py
+++ b/buildpack/runtime_components/storage.py
@@ -98,6 +98,10 @@ def _get_s3_specific_config(vcap_services, m2ee):
                 m2ee.config.get_runtime_version() >= MXVersion("8.18.7")
                 and m2ee.config.get_runtime_version() < 9
             )
+            or (
+                m2ee.config.get_runtime_version() >= MXVersion("7.23.22")
+                and m2ee.config.get_runtime_version() < 8
+            )
         )
     ):
         logging.info("S3 TVM config detected, activating external file store")

--- a/buildpack/runtime_components/storage.py
+++ b/buildpack/runtime_components/storage.py
@@ -116,7 +116,7 @@ def _get_s3_specific_config(vcap_services, m2ee):
             "S3 TVM config detected, fetching IAM credentials from TVM"
         )
         access_key, secret = _get_credentials_from_tvm(
-            tvm_endpoint, tvm_username, tvm_password
+            tvm_endpoint, tvm_username, tvm_password, m2ee
         )
         config = {
             "com.mendix.core.StorageService": "com.mendix.storage.s3",
@@ -147,14 +147,16 @@ def _get_s3_specific_config(vcap_services, m2ee):
     return config
 
 
-def _get_credentials_from_tvm(tvm_endpoint, tvm_username, tvm_password):
+def _get_credentials_from_tvm(tvm_endpoint, tvm_username, tvm_password, m2ee):
     retry = 3
     while True:
         response = requests.get(
             "https://%s/v1/getcredentials" % tvm_endpoint,
             headers={
-                "User-Agent": "Mendix Runtime %s"
-                % util.get_buildpack_version()
+                "User-Agent": "Mendix Buildpack {} (for Mendix {})".format(
+                    util.get_buildpack_version(),
+                    m2ee.config.get_runtime_version(),
+                )
             },
             auth=(tvm_username, tvm_password),
         )


### PR DESCRIPTION
* Fetch STS token from TVM for Mendix >= 7.23.22
* Fetch STS token from TVM for Mendix >= 8.18.7
* Fix User-Agent header when fetching STS token from TVM