### PR TITLE
Move to latest version of metering sidecar

### DIFF
--- a/buildpack/metering.py
+++ b/buildpack/metering.py
@@ -7,7 +7,7 @@ from buildpack import util
 from buildpack.runtime_components import database
 
 NAMESPACE = "metering"
-SIDECAR_VERSION = "v1.0.0"
+SIDECAR_VERSION = "v1.0.1"
 SIDECAR_ARCHIVE = "metering-sidecar-linux-amd64-{}.tar.gz".format(
     SIDECAR_VERSION
 )


### PR DESCRIPTION
This change bumps the version of the metering sidecar. This version will set the default value of `is_anonymous` to null instead of `false`.