### PR TITLE
Fix runtime-initiated shutdown

### DIFF
--- a/buildpack/start.py
+++ b/buildpack/start.py
@@ -155,4 +155,4 @@ if __name__ == "__main__":
     try:
         runtime.await_termination(m2ee)
     except KeyboardInterrupt:
-        logging.debug("Interrupt or termination signal received")
+        logging.debug("Interrupt signal received")

--- a/tests/integration/test_debug_container.py
+++ b/tests/integration/test_debug_container.py
@@ -8,7 +8,7 @@ class TestCaseDebugContainer(basetest.BaseTest):
             "BuildpackTestApp-mx-7-16.mda",
             env_vars={"DEBUG_CONTAINER": "true"},
         )
-        self.start_container(status="unhealthy")
+        self.start_container(health="unhealthy")
 
     def _assert_maintenance(self, response):
         assert response.status_code == 503

--- a/tests/integration/test_termination.py
+++ b/tests/integration/test_termination.py
@@ -3,15 +3,16 @@ from tests.integration import basetest
 
 class TestCaseTermination(basetest.BaseTest):
 
-    # Tests if termination works if the runtime shuts down by itself
-    def test_termination_runtime_intiated(self):
+    # Tests if termination works if a shutdown command is sent to the runtime
+    def test_termination_shutdown_command(self):
         self.stage_container("Mendix8.1.1.58432_StarterApp.mda")
         self.start_container()
         self.assert_app_running()
         self.query_mxadmin({"action": "shutdown"})
         self.assert_string_in_recent_logs("Mendix Runtime is shutting down")
         self.assert_string_in_recent_logs("Mendix Runtime is now shut down")
-        assert self.await_container_status("unhealthy", 60)
+        assert self.await_container_health("unhealthy", 60)
+        assert self.get_container_exitcode() == 0
 
     # Tests if the runtime is shut down gracefully on SIGTERM
     def test_termination_sigterm(self):
@@ -21,7 +22,8 @@ class TestCaseTermination(basetest.BaseTest):
         self.terminate_container()
         self.assert_string_in_recent_logs("Mendix Runtime is shutting down")
         self.assert_string_in_recent_logs("Mendix Runtime is now shut down")
-        assert self.await_container_status("unhealthy"), 60
+        assert self.await_container_health("unhealthy"), 60
+        assert self.get_container_exitcode() == 0
 
     # Tests that the process terminates with a stack trace when Python code
     # errors. The env variable S3_ENCRYPTION_KEYS is used here, it doesn't
@@ -36,6 +38,7 @@ class TestCaseTermination(basetest.BaseTest):
         self.assert_string_in_recent_logs(
             'json.loads(os.getenv("S3_ENCRYPTION_KEYS"))'
         )
+        assert self.get_container_exitcode() == 1
 
     # Tests if a broken application terminates
     def test_termination_broken_application(self):
@@ -43,9 +46,10 @@ class TestCaseTermination(basetest.BaseTest):
             "Sample-StartError-7.23.2.mda",
             env_vars={"METRICS_INTERVAL": "10",},
         )
-        self.start_container(status="unhealthy")
+        self.start_container(health="unhealthy")
         self.assert_string_in_recent_logs("start failed")
         self.assert_string_not_in_recent_logs("health check never passed")
+        assert self.get_container_exitcode() == 1
 
     # Tests if killing Java terminates the container
     def test_termination_java_crash_triggers_unhealthy(self):
@@ -55,4 +59,5 @@ class TestCaseTermination(basetest.BaseTest):
         self.start_container()
         self.assert_app_running()
         self.run_on_container("killall java")
-        assert self.await_container_status("unhealthy", 60)
+        assert self.await_container_health("unhealthy", 60)
+        assert self.get_container_exitcode() == 1

--- a/tests/integration/test_termination.py
+++ b/tests/integration/test_termination.py
@@ -3,14 +3,25 @@ from tests.integration import basetest
 
 class TestCaseTermination(basetest.BaseTest):
 
-    # Tests if the runtime is gracefully shut down
-    def test_termination_graceful_shutdown(self):
+    # Tests if termination works if the runtime shuts down by itself
+    def test_termination_runtime_intiated(self):
+        self.stage_container("Mendix8.1.1.58432_StarterApp.mda")
+        self.start_container()
+        self.assert_app_running()
+        self.query_mxadmin({"action": "shutdown"})
+        self.assert_string_in_recent_logs("Mendix Runtime is shutting down")
+        self.assert_string_in_recent_logs("Mendix Runtime is now shut down")
+        assert self.await_container_status("unhealthy", 60)
+
+    # Tests if the runtime is shut down gracefully on SIGTERM
+    def test_termination_sigterm(self):
         self.stage_container("Mendix8.1.1.58432_StarterApp.mda")
         self.start_container()
         self.assert_app_running()
         self.terminate_container()
         self.assert_string_in_recent_logs("Mendix Runtime is shutting down")
         self.assert_string_in_recent_logs("Mendix Runtime is now shut down")
+        assert self.await_container_status("unhealthy"), 60
 
     # Tests that the process terminates with a stack trace when Python code
     # errors. The env variable S3_ENCRYPTION_KEYS is used here, it doesn't
@@ -26,6 +37,7 @@ class TestCaseTermination(basetest.BaseTest):
             'json.loads(os.getenv("S3_ENCRYPTION_KEYS"))'
         )
 
+    # Tests if a broken application terminates
     def test_termination_broken_application(self):
         self.stage_container(
             "Sample-StartError-7.23.2.mda",
@@ -35,6 +47,7 @@ class TestCaseTermination(basetest.BaseTest):
         self.assert_string_in_recent_logs("start failed")
         self.assert_string_not_in_recent_logs("health check never passed")
 
+    # Tests if killing Java terminates the container
     def test_termination_java_crash_triggers_unhealthy(self):
         self.stage_container(
             "sample-6.2.0.mda", env_vars={"METRICS_INTERVAL": "10",},
@@ -42,5 +55,4 @@ class TestCaseTermination(basetest.BaseTest):
         self.start_container()
         self.assert_app_running()
         self.run_on_container("killall java")
-
         assert self.await_container_status("unhealthy", 60)


### PR DESCRIPTION
This PR fixes runtime-initiated shutdown, i.e. when the Mendix runtime crashes.

In previous buildpack versions, an additional exit handler would kill the entire main process group for the container. This handler was regrettably removed in #433, causing child processes to keep on running, thus preventing container termination.

To prevent shutdown issues from happening again, this PR also includes much-improved testing for shutdown logic.