### PR TITLE
Disable proxy buffering for files

### DIFF
--- a/buildpack/nginx.py
+++ b/buildpack/nginx.py
@@ -220,7 +220,8 @@ class Location:
     def __init__(self):
         self.path = None
         self.index = None
-        self.proxy_intercept_errors = "off"
+        self.proxy_buffering_enabled = True
+        self.proxy_intercept_errors_enabled = False
         self.satisfy = "any"
         self.ipfilter_ips = None
         self.basic_auth_enabled = False
@@ -239,6 +240,8 @@ def get_access_restriction_locations():
     # Default for satisfy is any
 
     restrictions = json.loads(os.environ.get("ACCESS_RESTRICTIONS", "{}"))
+    if "/file" not in restrictions:
+        restrictions["/file"] = {}
     if "/" not in restrictions:
         restrictions["/"] = {}
 
@@ -254,6 +257,9 @@ def get_access_restriction_locations():
             raise Exception(
                 "Can not override access restrictions on system path %s" % path
             )
+        if path in ["/file"]:
+            location.proxy_buffering_enabled = False
+            location.proxy_intercept_errors_enabled = True
         if path in [
             "/",
             "/p/",
@@ -264,7 +270,7 @@ def get_access_restriction_locations():
             "/ws-doc/",
             "/rest-doc",
         ]:
-            location.proxy_intercept_errors = "on"
+            location.proxy_intercept_errors_enabled = True
 
         if "satisfy" in config:
             if config["satisfy"] in ["any", "all"]:

--- a/etc/nginx/conf/nginx.conf.j2
+++ b/etc/nginx/conf/nginx.conf.j2
@@ -71,7 +71,13 @@ http {
         error_page 503 @503-custom;
 
         {% macro location_body(location) -%}
-        proxy_intercept_errors {{ location.proxy_intercept_errors }};
+        {% if not location.proxy_buffering_enabled %}
+        proxy_buffering off;
+        proxy_request_buffering off;
+        {% endif %}
+        {% if location.proxy_intercept_errors_enabled %}
+        proxy_intercept_errors on;
+        {% endif %}
         satisfy {{ location.satisfy }};
         {% if location.ipfilter_ips is not none %}
         {% for ip in location.ipfilter_ips %}


### PR DESCRIPTION
This PR disables `nginx` proxy (request) buffering for the runtime file handler endpoint (`/file`).
Additionally, it refactors the location `proxy_intercept_errors` setting to match the proxy buffering setting.

---

Tested by sshing into the app container and verifying the Nginx config:
```
> cf ssh d0979a7c-0476-4df3-b984-a15085ce4132
vcap@bf5a202e-cf80-4d6a-5bee-8ed6:~$ cd app/
vcap@bf5a202e-cf80-4d6a-5bee-8ed6:~/app$ ./nginx/sbin/nginx -p nginx/ -c /home/vcap/app/nginx/conf/nginx.conf -T | grep -A 10 "location \/file"
nginx: the configuration file /home/vcap/app/nginx/conf/nginx.conf syntax is ok
nginx: configuration file /home/vcap/app/nginx/conf/nginx.conf test is successful
        location /file {
            if ($request_uri ~ ^/(.*\.(css|js)|forms/.*|img/.*|pages/.*)\?[0-9]+$) {
                    expires 1y;
            }
            proxy_pass http://mendix;
                    proxy_buffering off;
            proxy_request_buffering off;
            proxy_intercept_errors on;
            satisfy any;

        }
```