### PR TITLE
Fix nginx error handling regression

### DIFF
--- a/buildpack/nginx.py
+++ b/buildpack/nginx.py
@@ -259,7 +259,6 @@ def get_access_restriction_locations():
             )
         if path in ["/file"]:
             location.proxy_buffering_enabled = False
-            location.proxy_intercept_errors_enabled = True
         if path in [
             "/",
             "/p/",
@@ -269,6 +268,7 @@ def get_access_restriction_locations():
             "/odata-doc/",
             "/ws-doc/",
             "/rest-doc",
+            "/file",
         ]:
             location.proxy_intercept_errors_enabled = True
 

--- a/etc/nginx/conf/nginx.conf.j2
+++ b/etc/nginx/conf/nginx.conf.j2
@@ -75,9 +75,7 @@ http {
         proxy_buffering off;
         proxy_request_buffering off;
         {% endif %}
-        {% if location.proxy_intercept_errors_enabled %}
-        proxy_intercept_errors on;
-        {% endif %}
+        proxy_intercept_errors {{ "on" if location.proxy_intercept_errors_enabled else "off" }};
         satisfy {{ location.satisfy }};
         {% if location.ipfilter_ips is not none %}
         {% for ip in location.ipfilter_ips %}


### PR DESCRIPTION
This PR fixes a regression which was introduced in #439. This regression caused errors for some locations (e.g. `/rest`) to be handled by the `nginx` proxy instead of the Mendix runtime.

The fix makes the `proxy_intercept_errors` explicit for each configured location.