### PR TITLE
Fix Telegraf metrics submission to non-US Datadog orgs

### DIFF
--- a/buildpack/telegraf.py
+++ b/buildpack/telegraf.py
@@ -161,7 +161,7 @@ def update_config(m2ee, app_name):
         database_diskstorage_metric_enabled=datadog.is_database_diskstorage_metric_enabled(),
         database_rate_count_metrics_enabled=datadog.is_database_rate_count_metrics_enabled(),
         datadog_api_key=datadog.get_api_key(),
-        datadog_url="{}series/".format(datadog.get_api_url()),
+        datadog_api_url="{}series/".format(datadog.get_api_url()),
         http_outputs=_get_http_outputs(),
     )
 

--- a/tests/integration/test_datadog.py
+++ b/tests/integration/test_datadog.py
@@ -13,6 +13,7 @@ class TestCaseDeployWithDatadog(basetest.BaseTestWithPostgreSQL):
                 "DD_API_KEY": os.environ.get(
                     "DD_API_KEY", "NON-VALID-TEST-KEY"
                 ),
+                "DD_SITE": os.environ.get("DD_SITE", "datadoghq.com"),
                 "DD_TRACE_ENABLED": "true",
                 # "DD_TRACE_DEBUG": "true",
                 "DD_PROFILING_ENABLED": "true",


### PR DESCRIPTION
This PR fixes Telegraf metrics submission for non-US Datadog orgs.