### PR TITLE
pass keySuffix based on key_prefix to the backup service

### DIFF
--- a/buildpack/runtime_components/backup.py
+++ b/buildpack/runtime_components/backup.py
@@ -27,10 +27,10 @@ def run():
         backup_service["filesCredentials"] = {
             "bucketName": s3_credentials["bucket"],
         }
-        if "key_suffix" in s3_credentials:  # Not all s3 plans have this field
-            backup_service["filesCredentials"]["keySuffix"] = s3_credentials[
-                "key_suffix"
-            ]
+        if "key_prefix" in s3_credentials:
+            backup_service["filesCredentials"][
+                "keySuffix"
+            ] = "_" + s3_credentials["key_prefix"].replace("/", "")
 
     try:
         db_config = database.get_config()


### PR DESCRIPTION
key_suffix has been removed from the s3-broker service. The backup service is still using the keySuffix to determine the folder in S3. key_prefix is actively used, so let's pass the keySuffix based on the key_prefix to keep the backup service working for now.