### PR TITLE
Fix "zip: not found" in Docker development image

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -11,6 +11,6 @@ RUN make install_requirements
 RUN wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | apt-key add - \
  && echo "deb https://packages.cloudfoundry.org/debian stable main" | tee /etc/apt/sources.list.d/cloudfoundry-cli.list \
  && apt-get update \
- && apt-get install -y cf-cli docker
+ && apt-get install -y cf-cli docker zip
 
 RUN cf install-plugin -f cflocal


### PR DESCRIPTION
This fixes #455.