### PR TITLE
Suppress Python bootstrap warnings

### DIFF
--- a/bin/bootstrap-python
+++ b/bin/bootstrap-python
@@ -6,6 +6,9 @@ BUILDPACK_PATH=$(dirname "$0")/..
 BUILD_PATH=$1
 CACHE_PATH=$2
 
+# This is set as a (temporary) solution for pip 21.2 and https://github.com/pypa/pip/issues/10151
+export _PIP_LOCATIONS_NO_WARN_ON_MISMATCH=1
+
 # Bootstrap and install the Python requirements from wheels.
 # Minimal packaging for the buildpack includes pip and setuptools wheels.
 REQUIREMENTS_PATH="${BUILDPACK_PATH}/requirements.txt"


### PR DESCRIPTION
This suppresses warnings related to https://github.com/pypa/pip/issues/10151 in the Python bootstrap script. It is a cosmetic fix only.