### PR TITLE
Fix development mode Python dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,11 @@ PROJECT_NAME := $(if $(PROJECT_NAME),$(PROJECT_NAME),cf-mendix-buildpack)
 PREFIX=$(shell p='$(TEST_PREFIX)'; echo "$${p:-test}")
 TEST_PROCESSES := $(if $(TEST_PROCESSES),$(TEST_PROCESSES),2)
 TEST_FILES := $(if $(TEST_FILES),$(TEST_FILES),tests/integration/test_*.py)
-MAX_LINE_LENGTH=$(shell cat .pylintrc | grep max-line-length | cut -d '=' -f 2 | xargs)
+MAX_LINE_LENGTH = $(shell cat .pylintrc | grep max-line-length | cut -d '=' -f 2 | xargs)
 
-PIP_TOOLS_VERSION=6.2.0
+PIP_TOOLS_VERSION = 6.2.0
+PYTHON_PLATFORM := $(if $(PYTHON_PLATFORM),$(PYTHON_PLATFORM),manylinux2014_x86_64)
+PYTHON_VERSION := $(if $(PYTHON_VERSION),$(PYTHON_VERSION),36)
 
 .PHONY: vendor
 vendor: download_wheels
@@ -14,7 +16,7 @@ download_wheels: requirements create_build_dirs
 	rm -rf build/vendor/wheels
 	mkdir -p build/vendor/wheels
 	pip3 download -d build/vendor/wheels/ --only-binary :all: pip setuptools wheel
-	pip3 download -d build/vendor/wheels/ --no-deps --platform manylinux2014_x86_64 --python-version 36 -r requirements.txt
+	pip3 download -d build/vendor/wheels/ --no-deps --platform ${PYTHON_PLATFORM} --python-version ${PYTHON_VERSION} -r requirements.txt
 
 .PHONY: create_build_dirs
 create_build_dirs:

--- a/bin/bootstrap-python
+++ b/bin/bootstrap-python
@@ -22,14 +22,23 @@ then
 fi
 
 PIP_WHEELDIR="${CACHE_PATH}/pip/wheels"
+mkdir -p $PIP_WHEELDIR
 # Set the correct Python site-packages directory to install to
 SITE_PACKAGES_PATH="${BUILD_PATH}/$(python3 -m site --user-site | cut -d '/' -f4-)"
 
-echo " ---> Copying bundled Python dependencies to cache...";
-mkdir -p $PIP_WHEELDIR;
-cp -rf $WHEELS_PATH/* $PIP_WHEELDIR/ 2>/dev/null
+# Invalidate the cache and copy over wheels if they are bundled
+# If no wheels are included, the cache will be left alone, as dependencies are downloaded
+echo " ---> Check if Python dependencies need to be cached..."
+if [[ $(ls -1q $WHEELS_PATH/* 2>/dev/null | wc -l) -gt 0 ]] && [[ $(diff $WHEELS_PATH $PIP_WHEELDIR 2>/dev/null | wc -l) -gt 0 ]]
+then
+    echo " ---> Invalidating Python wheels cache..."
+    rm -rf $PIP_WHEELDIR
+    echo " ---> Copying bundled Python dependencies to cache...";
+    mkdir -p $PIP_WHEELDIR
+    cp -rf $WHEELS_PATH/* $PIP_WHEELDIR/ 2>/dev/null
+fi    
 
-echo " ---> Bootstrapping pip, setuptools and wheel..."
+echo " ---> Bootstrapping pip..."
 PIP_CMD="pip"
 if ! [[ -x "$(command -v ${PIP_CMD})" ]]
 then
@@ -50,16 +59,14 @@ else
 fi
 
 # Only download Python dependencies if they are not bundled
-# We can assume that they're not if the amount of bundled wheels is less than 3 (the bootstrap requirements)
-if [[ $(ls -1q $PIP_WHEELDIR/*.whl 2>/dev/null | wc -l) -lt 4 ]]
+if [[ $(ls -1q $WHEELS_PATH/* 2>/dev/null | wc -l) -gt 0 ]]
 then
-    echo " ---> Downloading Python dependencies...";
-    $PIP_CMD download $PIP_VERBOSITY_FLAGS -r $REQUIREMENTS_PATH --prefer-binary -d $PIP_WHEELDIR;
+    echo " ---> Using bundled Python dependencies"
 else
-    # Assume that more than two wheels present implies that dependencies are bundled
-    echo " ---> Using bundled Python dependencies";
+    echo " ---> Downloading Python dependencies..."
+    $PIP_CMD download $PIP_VERBOSITY_FLAGS -r $REQUIREMENTS_PATH --prefer-binary -d $PIP_WHEELDIR
 fi
 
 echo " ---> Installing Python dependencies to ${SITE_PACKAGES_PATH}..."
-$PIP_CMD install $PIP_VERBOSITY_FLAGS --target $SITE_PACKAGES_PATH --no-warn-script-location --no-index --find-links=$PIP_WHEELDIR -r $REQUIREMENTS_PATH
+$PIP_CMD install $PIP_VERBOSITY_FLAGS --target $SITE_PACKAGES_PATH --prefer-binary --no-warn-script-location --no-index --find-links=$PIP_WHEELDIR -r $REQUIREMENTS_PATH
 echo " ---> Finished installing Python dependencies"


### PR DESCRIPTION
This PR fixes issues with Python dependencies in "development mode", i.e. the buildpack running from source instead of a release. In effect, the cache will not be invalidated if the buildpack is running from source, and cached dependencies will be used when possible.

The bootstrap script is changed in such a way that:
- If there are bundled dependencies, and they differ from the ones in the wheel cache, the current cache is invalidated and the bundled dependencies are cached
- If there are no bundled dependencies, the dependencies are always downloaded to the cache
- For both download and installation, binary versions of dependencies are preferred