### PR TITLE
FIX: change startup order for buildpack components

### DIFF
--- a/buildpack/start.py
+++ b/buildpack/start.py
@@ -164,8 +164,8 @@ if __name__ == "__main__":
         telegraf.run()
         datadog.run(model_version, runtime_version)
         metering.run()
-        nginx.run()
         runtime.run(m2ee)
+        nginx.run()
 
         # Wait for the runtime to be ready before starting Databroker
         if databroker.is_enabled():


### PR DESCRIPTION
## An explanation of the use cases your change solves

When resuming a Free-App it most often shows an HTTP 502 page when the app is "reachable".

![502-free-app](https://user-images.githubusercontent.com/11172501/132204966-af22cdd4-1a21-426c-905e-0c9c1b21a1e1.gif)

## An explanation of the proposed change

We found that startup procedure has changed in the cf-mendix-buipack [v4.16.0](https://github.com/mendix/cf-mendix-buildpack/releases/tag/v4.16.0) release.

Before v4.16.0 the order was the following [1]:
```
runtime.run_components(m2ee)
nginx_process = nginx.run()
```

After v4.16.0 the order changed to run the Nginx process first and only then start the runtime [2].
```
nginx.run()
runtime.run(m2ee)
```

Since the Nginx is considered the main process (listening on port 8080), Cloud Foundry indicates [3] that app is healthy as soon as TCP connection is established on port 8080, while the runtime process is still not started at this point.

[1] https://github.com/mendix/cf-mendix-buildpack/commit/609a98c02#diff-1cc393fec9d9f4aecb53e0ec7d088d0b8d22376ca1b56c7c5db5f6327270209fL209-L211
[2] https://github.com/mendix/cf-mendix-buildpack/commit/609a98c02#diff-1cc393fec9d9f4aecb53e0ec7d088d0b8d22376ca1b56c7c5db5f6327270209fR150-R151
[3] https://docs.cloudfoundry.org/devguide/deploy-apps/healthchecks.html#healthcheck-lifecycle

Signed-off-by: Andrei Krasnitski <andrei.krasnitski@mendix.com>