### PR TITLE
Disable S3 STS support when CAs are set

### DIFF
--- a/buildpack/runtime_components/storage.py
+++ b/buildpack/runtime_components/storage.py
@@ -80,6 +80,7 @@ def _get_s3_specific_config(vcap_services, m2ee):
     if not bucket:
         return None
 
+    cas = os.getenv("CERTIFICATE_AUTHORITIES", None)
     if access_key and secret:
         logging.info("S3 config detected, activating external file store")
         config = {
@@ -103,6 +104,7 @@ def _get_s3_specific_config(vcap_services, m2ee):
                 and m2ee.config.get_runtime_version() < 8
             )
         )
+        and not cas
     ):
         logging.info("S3 TVM config detected, activating external file store")
         config = {


### PR DESCRIPTION
There is currently a bug in the Mendix Runtime where it fails to use the configured CAs when STS is used.

Only configure the Mendix Runtime to use STS tokens for S3 access when the `CERTIFICATE_AUTHORITIES` environment variable is not set.