### PR TITLE
Add support for metrics via micrometer

### DIFF
--- a/buildpack/mx_java_agent.py
+++ b/buildpack/mx_java_agent.py
@@ -12,7 +12,7 @@ ROOT_DIR = ".local"
 
 def is_enabled(runtime_version):
     return meets_version_requirements(runtime_version) and (
-        telegraf.is_enabled() or datadog.is_enabled()
+        telegraf.is_enabled(runtime_version) or datadog.is_enabled()
     )
 
 

--- a/buildpack/runtime_components/metrics.py
+++ b/buildpack/runtime_components/metrics.py
@@ -121,6 +121,9 @@ def configure_influx_registry(m2ee):
     if not micrometer_metrics_enabled(m2ee.config.get_runtime_version()):
         return {}
 
+    logging.info(
+        "Configuring runtime to push metrics to influx via micrometer"
+    )
     return {"Metrics.Registries": METRICS_REGISTRY}
 
 

--- a/buildpack/stage.py
+++ b/buildpack/stage.py
@@ -158,7 +158,9 @@ if __name__ == "__main__":
     mx_java_agent.stage(
         BUILDPACK_DIR, DOT_LOCAL_LOCATION, CACHE_DIR, runtime_version
     )
-    telegraf.stage(BUILDPACK_DIR, DOT_LOCAL_LOCATION, CACHE_DIR)
+    telegraf.stage(
+        BUILDPACK_DIR, DOT_LOCAL_LOCATION, CACHE_DIR, runtime_version
+    )
     datadog.stage(BUILDPACK_DIR, DOT_LOCAL_LOCATION, CACHE_DIR)
     metering.stage(BUILDPACK_DIR, BUILD_DIR, CACHE_DIR)
     runtime.stage(BUILDPACK_DIR, BUILD_DIR, CACHE_DIR)

--- a/buildpack/start.py
+++ b/buildpack/start.py
@@ -161,7 +161,7 @@ if __name__ == "__main__":
         nginx.configure(m2ee)
 
         # Start components and runtime
-        telegraf.run()
+        telegraf.run(runtime_version)
         datadog.run(model_version, runtime_version)
         metering.run()
         runtime.run(m2ee)

--- a/buildpack/telegraf.py
+++ b/buildpack/telegraf.py
@@ -183,7 +183,7 @@ def update_config(m2ee, app_name):
         file_.write(rendered)
     logging.debug("Telegraf configuration file written")
 
-    logging.debug("Update runtime configuration... ")
+    logging.debug("Update runtime configuration for metrics registry... ")
     m2ee.config._conf["mxruntime"].update(
         metrics.configure_influx_registry(m2ee)
     )

--- a/etc/telegraf/telegraf.toml.j2
+++ b/etc/telegraf/telegraf.toml.j2
@@ -52,7 +52,7 @@
 #   The workaround is to append _rate and _count to those metrics and to do rollup in Datadog based on the Telegraf agent interval settings
 [[inputs.postgresql_extensible]]
     address = "postgres://{{ db_config['DatabaseUserName'] }}:{{ db_config['DatabasePassword'] }}@{{ db_config['DatabaseHost'] }}/{{ db_config['DatabaseName'] }}"
-    
+
     # Drop fields not present in the Datadog Agent PostgreSQL check
     fielddrop = ["datname"]
 
@@ -165,7 +165,7 @@
         version = 901
         withdbname = false
         tagvalue = "schema"
-        measurement = "postgresql.table" 
+        measurement = "postgresql.table"
     {% if database_rate_count_metrics_enabled %}
 
     # pg_stat_database metrics (rates)
@@ -254,6 +254,9 @@
     {% if datadog_api_url %}
     url = "{{ datadog_api_url }}"
     {% endif %}
+    # Ignore any micrometer_metrics
+    [outputs.datadog.tagdrop]
+        micrometer_metrics = ["true"]
 {% endif %}
 
 {% if http_outputs %}
@@ -271,6 +274,64 @@
     {% if http_output.kpionly %}
     [outputs.http.tagpass]
         KPI = ["true"]
+    {% else %}
+    # Ignore any micrometer_metrics
+    [outputs.http.tagdrop]
+        micrometer_metrics = ["true"]
     {% endif %}
 {% endfor %}
+{% endif %}
+
+{% if micrometer_metrics %}
+####################################################################################
+# App metrics via micrometer                                                       #
+####################################################################################
+# Input telegraf input
+[[inputs.influxdb_listener]]
+  ## Address and port to host HTTP listener on
+  service_address = ":8086"
+
+  ## maximum duration before timing out read of the request
+  read_timeout = "10s"
+  ## maximum duration before timing out write of the response
+  write_timeout = "10s"
+
+  ## Maximum allowed HTTP request body size in bytes.
+  ## 0 means to use the default of 32MiB.
+  max_body_size = 0
+
+  [inputs.influxdb_listener.tags]
+  micrometer_metrics = "true"
+  instance_index = "{{ cf_instance_index }}"
+  app_name = "{{ app_name }}"
+
+[[outputs.http]]
+  ## URL is the address to send metrics to
+  url = "{{ trends_storage_url }}"
+
+  ## Timeout for HTTP message
+  timeout = "10s"
+
+  ## HTTP method, one of: "POST" or "PUT"
+  method = "POST"
+
+  ## Data format to output.
+  data_format = "json"
+  json_timestamp_units = "1ns"
+
+  # tagexlude drops the custom tag set for micrometer metrics
+  # and any other non-relevant tags
+  tagexclude = ["micrometer_metrics", "host", "metric_type"]
+
+  ## Additional HTTP headers
+  [outputs.http.headers]
+  Content-Type = "application/json"
+  # custom header field
+  Micrometer-Metrics = "true"
+
+  # Pass only those metrics that has below tag set
+  [outputs.http.tagpass]
+  micrometer_metrics = ["true"]
+
+####################################################################################
 {% endif %}

--- a/tests/integration/test_telegraf.py
+++ b/tests/integration/test_telegraf.py
@@ -1,9 +1,28 @@
+import os
+
 from buildpack import telegraf
 from tests.integration import basetest
 
 
 class TestCaseTelegraf(basetest.BaseTest):
+    def _stage_test_app(self, env=None):
+        """Stage a compatible test app for tests with telegraf"""
+        # TODO : DISABLE_MICROMETER_METRICS would eventually be removed
+        # once we go live with the micrometer metrics stream.
+        if not env:
+            env = {
+                "TRENDS_STORAGE_URL": "some-fake-url",
+                "DISABLE_MICROMETER_METRICS": "false",
+            }
+        self.stage_container(
+            "BuildpackTestApp-mx9-7.mda",
+            env_vars=env,
+        )
+        self.start_container()
+        self.assert_app_running()
+
     def test_telegraf_running(self):
+        """Ensure telegraf running when APPMETRICS_TARGET set"""
         self.stage_container(
             "BuildpackTestApp-mx-7-16.mda",
             env_vars={"APPMETRICS_TARGET": '{"url": "https://foo.bar/write"}'},
@@ -13,3 +32,78 @@ class TestCaseTelegraf(basetest.BaseTest):
         self.assert_listening_on_port(telegraf.get_statsd_port(), "telegraf")
         self.assert_string_not_in_recent_logs("E! [inputs.postgresql]")
         self.assert_string_not_in_recent_logs("E! [processors.")
+
+    def test_telegraf_not_running_runtime_less_than_mx9_7(self):
+        """Ensure telegraf is not running for runtimes less than 9.7.0
+
+        Scenario where we have not enabled APPMETRICS_TARGET or Datadog.
+        """
+        self.stage_container(
+            "BuildpackTestApp-mx9-6.mda",
+        )
+        self.start_container()
+        self.assert_string_not_in_recent_logs("Starting Telegraf")
+
+    def test_telegraf_not_running_runtime_mx9_7_force_disabled(self):
+        """Ensure telegraf is not running for runtime 9.7.0 unless forced
+
+        TODO : Temporary check to test the feature flag
+        """
+        self._stage_test_app(
+            env={
+                "DISABLE_MICROMETER_METRICS": "true",
+            }
+        )
+        self.assert_string_not_in_recent_logs("Starting Telegraf")
+
+    def test_telegraf_running_runtime_greater_than_mx9_7(self):
+        """Ensure telegraf is running for runtimes greater than or equal to 9.7.0
+
+        Starting runtime version 9.7.0, telegraf is expected to be
+        enabled to handle metrics send from micrometer.
+        """
+        self._stage_test_app()
+        self.await_string_in_recent_logs("Starting Telegraf", max_time=5)
+        self.assert_running("telegraf")
+        self.await_string_in_recent_logs(
+            "Metrics: Adding metrics registry InfluxMeterRegistry", max_time=5
+        )
+
+    def test_telegraph_config_for_micrometer(self):
+        """Ensure telegraf is configured to collect metrics from micrometer"""
+        version = telegraf.VERSION
+        telegraf_config_path = os.path.join(
+            os.sep,
+            "app",
+            ".local",
+            "telegraf",
+            f"telegraf-{version}",
+            "etc",
+            "telegraf",
+            "telegraf.conf",
+        )
+        self._stage_test_app()
+        # Ensure we have the influxdb_listener plugin added
+        output = self.run_on_container(
+            "cat {} | grep -A2 inputs.influxdb_listener".format(
+                telegraf_config_path
+            )
+        )
+        assert output is not None
+        assert str(output).find("influxdb_listener") >= 0
+
+        # Ensure the trends-storage-url is set
+        output = self.run_on_container(
+            "cat {} | grep -A2 outputs.http".format(telegraf_config_path)
+        )
+        assert output is not None
+        assert str(output).find("some-fake-url") >= 0
+
+        # Ensure we have the appropriate headers
+        output = self.run_on_container(
+            "cat {} | grep -A5 outputs.http.headers".format(
+                telegraf_config_path
+            )
+        )
+        assert output is not None
+        assert str(output).find("Micrometer-Metrics") >= 0

--- a/tests/unit/test_micrometer_metrics.py
+++ b/tests/unit/test_micrometer_metrics.py
@@ -1,0 +1,35 @@
+import os
+
+from buildpack.runtime_components import metrics
+
+from unittest import TestCase
+from unittest.mock import patch
+
+
+class TestMicrometerMetrics(TestCase):
+    def setUp(self) -> None:
+        self.addCleanup(patch.stopall)
+        patch(
+            "buildpack.runtime_components.metrics.get_metrics_url",
+            return_value="non_empty_url",
+        ).start()
+
+    def test_old_runtime_forced_to_disable(self):
+        with patch.dict(os.environ, {"DISABLE_MICROMETER_METRICS": "true"}):
+            actual_state = metrics.micrometer_metrics_enabled("9.0.0")
+        self.assertFalse(actual_state)
+
+    def test_old_runtime_not_forced_to_disable(self):
+        with patch.dict(os.environ, {"DISABLE_MICROMETER_METRICS": "false"}):
+            actual_state = metrics.micrometer_metrics_enabled("9.0.0")
+        self.assertFalse(actual_state)
+
+    def test_new_runtime_forced_to_disable(self):
+        with patch.dict(os.environ, {"DISABLE_MICROMETER_METRICS": "true"}):
+            actual_state = metrics.micrometer_metrics_enabled("9.7.0")
+        self.assertFalse(actual_state)
+
+    def test_new_runtime_not_forced_to_disable(self):
+        with patch.dict(os.environ, {"DISABLE_MICROMETER_METRICS": "false"}):
+            actual_state = metrics.micrometer_metrics_enabled("9.7.0")
+        self.assertTrue(actual_state)

--- a/tests/unit/test_telegraf.py
+++ b/tests/unit/test_telegraf.py
@@ -1,0 +1,40 @@
+import os
+
+from buildpack import telegraf
+
+from unittest import TestCase
+from unittest.mock import patch
+
+
+@patch("buildpack.runtime_components.metrics.micrometer_metrics_enabled")
+@patch("buildpack.datadog.is_enabled")
+class TestTelegrafIsEnabled(TestCase):
+    def test_when_only_appmetrics_target_is_given(
+        self, mock_datadog_is_enabled, mock_micrometer_metrics_enabled
+    ):
+        mock_datadog_is_enabled.return_value = False
+        mock_micrometer_metrics_enabled.return_value = False
+        with patch.dict(os.environ, {"APPMETRICS_TARGET": "non_empty_value"}):
+            actual_state = telegraf.is_enabled("dummy_runtime")
+        self.assertTrue(actual_state)
+
+    def test_when_only_datadog_is_enabled(
+        self, mock_datadog_is_enabled, mock_micrometer_metrics_enabled
+    ):
+        mock_datadog_is_enabled.return_value = True
+        mock_micrometer_metrics_enabled.return_value = False
+        self.assertTrue(telegraf.is_enabled("dummy_runtime"))
+
+    def test_when_only_micrometer_metrics_are_enabled(
+        self, mock_datadog_is_enabled, mock_micrometer_metrics_enabled
+    ):
+        mock_datadog_is_enabled.return_value = False
+        mock_micrometer_metrics_enabled.return_value = True
+        self.assertTrue(telegraf.is_enabled("dummy_runtime"))
+
+    def test_when_nothing_is_enabled(
+        self, mock_datadog_is_enabled, mock_micrometer_metrics_enabled
+    ):
+        mock_datadog_is_enabled.return_value = False
+        mock_micrometer_metrics_enabled.return_value = False
+        self.assertFalse(telegraf.is_enabled("dummy_runtime"))


### PR DESCRIPTION
The pull request consists of the following changes to add support for metrics via micrometer:

- Enable & install Telegraf agent for runtime >= **9.7**
- Telegraf config changes to accept metrics from micrometer and push to trends-storage-server
- Runtime config settings to register telegraf as an output for micrometer

These changes do not affect the use cases where certain apps were collecting metrics using telegraf via APPMETRICS_TARGET or Datadog.


This PR however **does not** include any of the following changes :
- additional transformations or calculations applied to the admin port metrics
- switching over of the metrics stream from the admin port to the micrometer one
The above changes will be handled in PR for LM-591

Closes LM-590