### PR TITLE
Add "+" to allowed Content-Security-Policy header

### DIFF
--- a/buildpack/nginx.py
+++ b/buildpack/nginx.py
@@ -13,7 +13,7 @@ from lib.m2ee.version import MXVersion
 
 from jinja2 import Template
 
-DEFAULT_HEADERS = {
+ALLOWED_HEADERS = {
     "X-Frame-Options": r"(?i)(^allow-from https?://([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*(:\d+)?$|^deny$|^sameorigin$)",  # noqa: E501
     "Referrer-Policy": r"(?i)(^no-referrer$|^no-referrer-when-downgrade$|^origin|origin-when-cross-origin$|^same-origin|strict-origin$|^strict-origin-when-cross-origin$|^unsafe-url$)",  # noqa: E501
     "Access-Control-Allow-Origin": r"(?i)(^\*$|^null$|^https?://([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*(:\d+)?$)",  # noqa: E501
@@ -176,7 +176,7 @@ def _get_http_headers():
 
     result = []
     for header_key, header_value in headers_from_json.items():
-        regEx = DEFAULT_HEADERS[header_key]
+        regEx = ALLOWED_HEADERS[header_key]
         if regEx and re.match(regEx, header_value):
             escaped_value = header_value.replace('"', '\\"').replace(
                 "'", "\\'"

--- a/buildpack/nginx.py
+++ b/buildpack/nginx.py
@@ -18,7 +18,7 @@ DEFAULT_HEADERS = {
     "Referrer-Policy": r"(?i)(^no-referrer$|^no-referrer-when-downgrade$|^origin|origin-when-cross-origin$|^same-origin|strict-origin$|^strict-origin-when-cross-origin$|^unsafe-url$)",  # noqa: E501
     "Access-Control-Allow-Origin": r"(?i)(^\*$|^null$|^https?://([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*(:\d+)?$)",  # noqa: E501
     "X-Content-Type-Options": r"(?i)(^nosniff$)",
-    "Content-Security-Policy": r"[a-zA-Z0-9:;/''\"\*_\- \.\n?=%&]+",
+    "Content-Security-Policy": r"[a-zA-Z0-9:;/''\"\*_\- \.\n?=%&+]+",
     "X-Permitted-Cross-Domain-Policies": r"(?i)(^all$|^none$|^master-only$|^by-content-type$|^by-ftp-filename$)",  # noqa: E501
     "X-XSS-Protection": r"(?i)(^0$|^1$|^1; mode=block$|^1; report=https?://([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*(:\d+)?$)",  # noqa: E501
 }

--- a/tests/unit/test_custom_headers.py
+++ b/tests/unit/test_custom_headers.py
@@ -90,6 +90,21 @@ class TestCaseCustomHeaderConfig(unittest.TestCase):
             header_config,
         )
 
+    def test_valid_header_contentSecurity_sha(self):
+        base64_src = r"default-src 'self'; style-src 'self' 'sha256-aBc/dEf='; script-src 'self' 'unsafe-eval' 'sha256-aBc+dEf=';"
+
+        os.environ["HTTP_RESPONSE_HEADERS"] = json.dumps(
+            {"Content-Security-Policy": base64_src}
+        )
+        header_config = nginx._get_http_headers()
+        self.assertIn(
+            (
+                "Content-Security-Policy",
+                base64_src.replace("'", "\\'"),
+            ),
+            header_config,
+        )
+
     def test_invalid_header_contentSecurity(self):
         os.environ["HTTP_RESPONSE_HEADERS"] = json.dumps(
             {


### PR DESCRIPTION
This PR introduces a fix for the allowed `Content-Security-Policy` header. It now allows including the `+` sign, which allows for `base64` strings in the header.