### PR TITLE
Switch to metrics via micrometer

### DIFF
--- a/buildpack/telemetry/metrics.py
+++ b/buildpack/telemetry/metrics.py
@@ -70,6 +70,10 @@ FREEAPPS_METRICS_REGISTRY = [
     }
 ]
 
+# From this MxRuntime version onwards we gather (available) runtime statistics
+# from the micrometer library via the telegraf agent
+MXVERSION_MICROMETER = MXVersion("9.7.0")
+
 # Handler for exit(0) and exit(1)
 def _stop():
     _emit(jvm={"crash": 1.0})
@@ -131,7 +135,7 @@ def _micrometer_runtime_requirement(runtime_version):
         os.getenv("DISABLE_MICROMETER_METRICS", "false")
     )
 
-    runtime_version_supported = runtime_version >= MXVersion("9.7.0")
+    runtime_version_supported = runtime_version >= MXVERSION_MICROMETER
 
     if not disable_micrometer and runtime_version_supported:
         return True

--- a/buildpack/telemetry/metrics.py
+++ b/buildpack/telemetry/metrics.py
@@ -243,7 +243,7 @@ class BaseMetricsEmitterThread(threading.Thread, metaclass=ABCMeta):
         self.m2ee = m2ee
         self.db = None
         self.micrometer_metrics_enabled = micrometer_metrics_enabled(
-            m2ee.config.get_runtime_version()
+            runtime.get_runtime_version()
         )
         if bypass_loggregator():
             logging.info("Metrics are logged direct to metrics server.")

--- a/buildpack/telemetry/metrics.py
+++ b/buildpack/telemetry/metrics.py
@@ -128,7 +128,7 @@ def _micrometer_runtime_requirement(runtime_version):
     # collection via micrometer till we are ready to do the switchover
     # from admin port metrics to micrometer based metrics
     disable_micrometer = strtobool(
-        os.getenv("DISABLE_MICROMETER_METRICS", "true")
+        os.getenv("DISABLE_MICROMETER_METRICS", "false")
     )
 
     runtime_version_supported = runtime_version >= MXVersion("9.7.0")

--- a/buildpack/telemetry/mx_java_agent.py
+++ b/buildpack/telemetry/mx_java_agent.py
@@ -129,8 +129,8 @@ def _enable_mx_java_agent(m2ee):
     )
 
     # If not explicitly set,
-    # - default to StatsD (MxVersion < 9.7)
-    # - default to micrometer (MxVersion >= 9.7)
+    # - default to StatsD (MxVersion < metrics.MXVERSION_MICROMETER)
+    # - default to micrometer (MxVersion >= metrics.MXVERSION_MICROMETER)
     # NOTE : Runtime is moving away from statsd type metrics. If we
     # have customers preferring statsd format, they would need to configure
     # StatsD registry for micrometer.

--- a/etc/telegraf/telegraf.toml.j2
+++ b/etc/telegraf/telegraf.toml.j2
@@ -10,7 +10,7 @@
     interval = "{{ interval }}s"
     round_interval = true
     metric_batch_size = 1000
-    metric_buffer_limit = 10000
+    metric_buffer_limit = 15000
     collection_jitter = "0s"
     flush_interval = "10s"
     flush_jitter = "5s"

--- a/tests/integration/test_micrometer_metrics.py
+++ b/tests/integration/test_micrometer_metrics.py
@@ -1,0 +1,65 @@
+from tests.integration import basetest
+
+
+class TestMicrometerMetricsFlow(basetest.BaseTestWithPostgreSQL):
+    """Test the metrics flow when metrics via micrometer is enabled.
+
+    Even with micrometer enabled, we still have the following list of metrics
+    pushed to TSS via python metrics emitter:
+    - database
+    - storage
+    - health
+    - smaps
+    - critical log count
+    Here we assume the metrics are written to STDOUT with BYPASS_LOGGREGATOR
+    set to false, which is not the case in production. These tests just ensure
+    the correct metrics are still being emitted.
+
+    Runtime stats like memory, threadpool are pushed to TSS via telegraf,
+    which are not being tested here.
+    """
+
+    def test_free_apps_metrics(self):
+        """Test no metrics for free apps via old stream."""
+        self.stage_container(
+            "BuildpackTestApp-mx9-7.mda",
+            env_vars={
+                "METRICS_INTERVAL": "10",
+                "DISABLE_MICROMETER_METRICS": "false",
+                "TRENDS_STORAGE_URL": "some-fake-url",
+                "PROFILE": "free",
+            },
+        )
+        self.start_container()
+        self.assert_app_running()
+
+        assert self.await_string_in_recent_logs("MENDIX-METRICS: ", 10)
+        self.assert_string_not_in_recent_logs('named_user_sessions":')
+        self.assert_string_not_in_recent_logs('anonymous_sessions":')
+        self.assert_string_not_in_recent_logs('health":')
+        self.assert_string_not_in_recent_logs('nativecode":')
+        self.assert_string_not_in_recent_logs('critical_logs_count":')
+
+    def test_paid_apps_metrics(self):
+        """Test selected metrics for paid apps via old stream."""
+        self.stage_container(
+            "BuildpackTestApp-mx9-7.mda",
+            env_vars={
+                "METRICS_INTERVAL": "10",
+                "DISABLE_MICROMETER_METRICS": "false",
+                "TRENDS_STORAGE_URL": "some-fake-url",
+            },
+        )
+        self.start_container()
+
+        assert self.await_string_in_recent_logs("MENDIX-METRICS: ", 10)
+        self.assert_string_in_recent_logs('indexes_size":')
+        self.assert_string_in_recent_logs('number_of_files":')
+        self.assert_string_in_recent_logs('health":')
+        self.assert_string_in_recent_logs('nativecode":')
+        self.assert_string_in_recent_logs('critical_logs_count":')
+        self.assert_string_not_in_recent_logs('named_user_sessions":')
+        self.assert_string_not_in_recent_logs('javaheap":')
+        self.assert_string_not_in_recent_logs('codecache":')
+        self.assert_string_not_in_recent_logs('requests":')
+        self.assert_string_not_in_recent_logs('active_threads":')

--- a/tests/unit/test_emit_metrics.py
+++ b/tests/unit/test_emit_metrics.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch, MagicMock
 from buildpack.telemetry.metrics import (
     FreeAppsMetricsEmitterThread,
     PaidAppsMetricsEmitterThread,
+    MXVERSION_MICROMETER,
 )
 from lib.m2ee.version import MXVersion
 
@@ -74,7 +75,7 @@ class TestFreeAppsMetricsEmitter(TestCase):
         self.addCleanup(patch.stopall)
         patch(
             "buildpack.core.runtime.get_runtime_version",
-            return_value=MXVersion(9.7),
+            return_value=MXVERSION_MICROMETER,
         ).start()
 
         self.mock_user_session_metrics = {

--- a/tests/unit/test_micrometer_metrics.py
+++ b/tests/unit/test_micrometer_metrics.py
@@ -1,9 +1,10 @@
 import os
 
 from buildpack.telemetry import metrics
+from lib.m2ee.version import MXVersion
 
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 
 class TestMicrometerMetrics(TestCase):
@@ -33,3 +34,32 @@ class TestMicrometerMetrics(TestCase):
         with patch.dict(os.environ, {"DISABLE_MICROMETER_METRICS": "false"}):
             actual_state = metrics.micrometer_metrics_enabled("9.7.0")
         self.assertTrue(actual_state)
+
+
+class TestMicrometerMetricRegistry(TestCase):
+    def setUp(self) -> None:
+        self.addCleanup(patch.stopall)
+        patch(
+            "buildpack.core.runtime.get_runtime_version",
+            return_value=MXVersion(9.7),
+        ).start()
+        patch(
+            "buildpack.telemetry.metrics.micrometer_metrics_enabled",
+            return_value=True,
+        ).start()
+
+    def test_paidapps_metrics_registry(self):
+        with patch.dict(os.environ, {"PROFILE": "some-random-mx-profile"}):
+            result = metrics.configure_influx_registry(Mock())
+            self.assertEqual(
+                result.get("Metrics.Registries"),
+                metrics.PAIDAPPS_METRICS_REGISTRY,
+            )
+
+    def test_freeapps_metrics_registry(self):
+        with patch.dict(os.environ, {"PROFILE": "free"}):
+            result = metrics.configure_influx_registry(Mock())
+            self.assertEqual(
+                result.get("Metrics.Registries"),
+                metrics.FREEAPPS_METRICS_REGISTRY,
+            )

--- a/tests/unit/test_micrometer_metrics.py
+++ b/tests/unit/test_micrometer_metrics.py
@@ -41,7 +41,7 @@ class TestMicrometerMetricRegistry(TestCase):
         self.addCleanup(patch.stopall)
         patch(
             "buildpack.core.runtime.get_runtime_version",
-            return_value=MXVersion(9.7),
+            return_value=metrics.MXVERSION_MICROMETER,
         ).start()
         patch(
             "buildpack.telemetry.metrics.micrometer_metrics_enabled",


### PR DESCRIPTION
Starting MxRuntime v9.7.0, runtime metrics will be fetched via micrometer instead of admin port.

This PR includes changes to :
- Switch off runtime application statistics from admin port, if metrics via micrometer is enabled
- Bump telegraf metric buffer limit from 10k -> 15k to address metric buffer overflow
- For freeapps, configure micrometer to push only session metrics

Known Issue:
---
Few runtime metrics is displayed as `NaN` in the trends graph if the action the metric represents has not been invoked yet. This affects MxRuntime v9.7.x and v9.8.x. This issue is fixed in MxRuntime v9.9.0