### PR TITLE
Remove official support for Mendix 9 < 9.6

### DIFF
--- a/buildpack/core/runtime.py
+++ b/buildpack/core/runtime.py
@@ -41,6 +41,8 @@ def is_version_end_of_support(version):
         return True
     if version >= MXVersion("8.0.0") and version < MXVersion("8.18"):
         return True
+    if version >= MXVersion("9.0.0") and version < MXVersion("9.6.0"):
+        return True
 
     return False
 

--- a/tests/unit/test_deprecations.py
+++ b/tests/unit/test_deprecations.py
@@ -3,6 +3,13 @@ from unittest import TestCase
 from buildpack.core import runtime
 from lib.m2ee.version import MXVersion
 
+"""
+Current supported versions (https://docs.mendix.com/releasenotes/studio-pro/lts-mts):
+- Mendix 7: 7.23.x (LTS)
+- Mendix 8: 8.18.x (LTS)
+- Mendix 9: 9.6.x (MTS), > 9.6 (monthly / latest)
+"""
+
 
 class TestCaseMxNotSupported(TestCase):
     def test_mx5_notsupported(self):
@@ -18,3 +25,6 @@ class TestCaseMxEndOfSupport(TestCase):
 
     def test_mx8_end_of_support(self):
         assert runtime.is_version_end_of_support(MXVersion("8.1.1"))
+
+    def test_mx9_end_of_support(self):
+        assert runtime.is_version_end_of_support(MXVersion("9.4.0"))


### PR DESCRIPTION
This PR aligns buildpack support with [official Mendix guidelines](https://docs.mendix.com/releasenotes/studio-pro/lts-mtshttps://docs.mendix.com/releasenotes/studio-pro/lts-mts).