### PR TITLE
Nginx should cache static client images

### DIFF
--- a/etc/nginx/conf/nginx.conf.j2
+++ b/etc/nginx/conf/nginx.conf.j2
@@ -93,7 +93,7 @@ http {
         {%- endmacro %}
         {% for location in locations %}
         location {{ location.path }} {
-            if ($request_uri ~ ^/(.*\.(css|js)|forms/.*|img/.*|pages/.*)\?[0-9]+$) {
+            if ($request_uri ~ ^/(.*\.(css|js)|forms/.*|img/.*|pages/.*|mxclientsystem/images/.*)\?[0-9]+$) {
                     expires 1y;
             }
         {% if location.path == "/" %}


### PR DESCRIPTION
The upcoming version of Mendix will have static images in a separate folder and should be cached in order for apps to continue working as expected.