### PR TITLE
Upgrade appdynamics java agent

### DIFF
--- a/buildpack/telemetry/appdynamics.py
+++ b/buildpack/telemetry/appdynamics.py
@@ -11,7 +11,7 @@ def stage(buildpack_dir, destination_path, cache_path):
         util.resolve_dependency(
             util.get_blobstore_url(
                 "/mx-buildpack/appdynamics/appdynamics-agent-1.8-{}.zip".format(
-                    APPDYNAMICS_VERSION + "-mendix"
+                    APPDYNAMICS_VERSION
                 )
             ),
             destination_path,  # DOT_LOCAL_LOCATION,

--- a/buildpack/telemetry/appdynamics.py
+++ b/buildpack/telemetry/appdynamics.py
@@ -3,7 +3,7 @@ import os
 
 from buildpack import util
 
-APPDYNAMICS_VERSION = "21.11.1.33280"
+APPDYNAMICS_VERSION = "22.1.0.33445"
 
 
 def stage(buildpack_dir, destination_path, cache_path):

--- a/tests/integration/test_appdynamics.py
+++ b/tests/integration/test_appdynamics.py
@@ -35,6 +35,9 @@ class TestCaseDeployWithAppdynamics(basetest.BaseTest):
             "Started AppDynamics Java Agent Successfully"
         )
 
+    def test_appdynamics_mx9(self):
+        self._test_appdynamics("BuildpackTestApp-mx9-7.mda")
+
     def test_appdynamics_mx8(self):
         self._test_appdynamics("Mendix8.1.1.58432_StarterApp.mda")
 


### PR DESCRIPTION
Upgrading appDynamics agent to the latest version (22.1.0).
Release description: https://docs.appdynamics.com/22.1/en/product-and-release-announcements/past-releases/past-agent-releases#PastAgentReleases-JavaAgent
Integration test case added for runtime version MX9.
