### PR TITLE
Use correct name for the env var that enables system metrics in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ Additionally, we configure the following Datadog environment variables for you:
 | `DD_JMXFETCH_ENABLED` | `true` | No | Enables Datadog Java Trace Agent JMX metrics fetching |
 | `DD_SERVICE_MAPPING` | `<database>:<app>.db` | No | Links your database to your app in Datadog APM |
 | `DD_LOGS_ENABLED` | `true` | No | Enables sending your application logs directly to Datadog |
-| `DD_CHECKS_ENABLED` | `false` | Yes | Enables system metrics. These are disabled by default, as the metrics might be host metrics instead of container metrics. |
+| `DD_ENABLE_CHECKS` | `false` | Yes | Enables system metrics. These are disabled by default, as the metrics might be host metrics instead of container metrics. |
 
 Other environment variables can be set as per the [Datadog Agent documentation](https://docs.datadoghq.com/agent/).
 


### PR DESCRIPTION
I figured out that the environment variable mentioned in the readme for enabling system metrics is not reflecting the correct environment variable that is used in the code.

The env var in the readme is `DD_CHECKS_ENABLED` which is not being used.
The correct env var is `DD_ENABLE_CHECKS`
