### PR TITLE
Fix regression for Metrics.Registries custom runtime setting

### DIFF
--- a/buildpack/telemetry/metrics.py
+++ b/buildpack/telemetry/metrics.py
@@ -74,6 +74,8 @@ FREEAPPS_METRICS_REGISTRY = [
     }
 ]
 
+METRICS_REGISTRIES_KEY = "Metrics.Registries"
+
 # From this MxRuntime version onwards we gather (available) runtime statistics
 # from the micrometer library via the telegraf agent
 MXVERSION_MICROMETER = MXVersion("9.7.0")

--- a/buildpack/telemetry/metrics.py
+++ b/buildpack/telemetry/metrics.py
@@ -166,16 +166,16 @@ def configure_metrics_registry(m2ee):
         "Configuring runtime to push metrics to influx via micrometer"
     )
     if util.is_free_app():
-        return {"Metrics.Registries": FREEAPPS_METRICS_REGISTRY}
+        return FREEAPPS_METRICS_REGISTRY
 
-    paidapps_registries = {"Metrics.Registries": [INFLUX_REGISTRY]}
+    paidapps_registries = [INFLUX_REGISTRY]
 
     if (
         datadog.is_enabled()
         or get_appmetrics_target()
         or appdynamics.machine_agent_enabled()
     ):
-        paidapps_registries["Metrics.Registries"].append(STATSD_REGISTRY)
+        paidapps_registries.append(STATSD_REGISTRY)
 
     return paidapps_registries
 

--- a/buildpack/telemetry/telegraf.py
+++ b/buildpack/telemetry/telegraf.py
@@ -170,10 +170,9 @@ def _fix_metrics_registries_config(m2ee):
     # Metrics.Registries is a nested JSON entry. As a result, when we read
     # from the environment, it is not a list of registries but a string.
     # We fix it here so that it is a list.
-    metrics_registries_key = "Metrics.Registries"
     try:
         metrics_registries_value = util.get_custom_runtime_setting(
-            m2ee, metrics_registries_key
+            m2ee, metrics.METRICS_REGISTRIES_KEY
         )
     except KeyError:
         # Move on if we do not have the key set
@@ -188,7 +187,10 @@ def _fix_metrics_registries_config(m2ee):
 
     # Update the registries with the fixed set of entries
     util.upsert_custom_runtime_setting(
-        m2ee, metrics_registries_key, current_registries, overwrite=True
+        m2ee,
+        metrics.METRICS_REGISTRIES_KEY,
+        current_registries,
+        overwrite=True,
     )
 
 
@@ -240,7 +242,7 @@ def update_config(m2ee, app_name):
     _fix_metrics_registries_config(m2ee)
     util.upsert_custom_runtime_setting(
         m2ee,
-        'Metrics.Registries',
+        metrics.METRICS_REGISTRIES_KEY,
         metrics.configure_metrics_registry(m2ee),
         overwrite=True,
         append=True,

--- a/buildpack/telemetry/telegraf.py
+++ b/buildpack/telemetry/telegraf.py
@@ -166,6 +166,32 @@ def _get_db_config():
     return None
 
 
+def _fix_metrics_registries_config(m2ee):
+    # Metrics.Registries is a nested JSON entry. As a result, when we read
+    # from the environment, it is not a list of registries but a string.
+    # We fix it here so that it is a list.
+    metrics_registries_key = "Metrics.Registries"
+    try:
+        metrics_registries_value = util.get_custom_runtime_setting(
+            m2ee, metrics_registries_key
+        )
+    except KeyError:
+        # Move on if we do not have the key set
+        return
+
+    try:
+        current_registries = json.loads(metrics_registries_value)
+    except TypeError:
+        # Type error indicates the value is not a string and we can
+        # then ignore it and continue
+        current_registries = metrics_registries_value
+
+    # Update the registries with the fixed set of entries
+    util.upsert_custom_runtime_setting(
+        m2ee, metrics_registries_key, current_registries, overwrite=True
+    )
+
+
 def update_config(m2ee, app_name):
     runtime_version = runtime.get_runtime_version()
     if not is_enabled(runtime_version) or not _is_installed():
@@ -211,8 +237,10 @@ def update_config(m2ee, app_name):
     logging.debug("Telegraf configuration file written")
 
     logging.debug("Update runtime configuration for metrics registry... ")
-    util.upsert_custom_runtime_settings(
+    _fix_metrics_registries_config(m2ee)
+    util.upsert_custom_runtime_setting(
         m2ee,
+        'Metrics.Registries',
         metrics.configure_metrics_registry(m2ee),
         overwrite=True,
         append=True,

--- a/tests/unit/test_micrometer_metrics.py
+++ b/tests/unit/test_micrometer_metrics.py
@@ -53,9 +53,8 @@ class TestMicrometerMetricRegistry(TestCase):
     def test_paidapps_metrics_registry(self, is_enabled):
         with patch.dict(os.environ, {"PROFILE": "some-random-mx-profile"}):
             result = metrics.configure_metrics_registry(Mock())
-            metrics_registries = result.get("Metrics.Registries")
             self.assertEqual(
-                metrics_registries[0]["type"],
+                result[0]["type"],
                 "influx",
             )
 
@@ -63,9 +62,7 @@ class TestMicrometerMetricRegistry(TestCase):
     def test_paidapps_metrics_registry_statsd(self, is_enabled):
         with patch.dict(os.environ, {"PROFILE": "some-random-mx-profile"}):
             result = metrics.configure_metrics_registry(Mock())
-            metrics_registries = sorted(
-                result.get("Metrics.Registries"), key=itemgetter("type")
-            )
+            metrics_registries = sorted(result, key=itemgetter("type"))
             self.assertEqual(
                 metrics_registries[0]["type"],
                 "influx",
@@ -79,6 +76,6 @@ class TestMicrometerMetricRegistry(TestCase):
         with patch.dict(os.environ, {"PROFILE": "free"}):
             result = metrics.configure_metrics_registry(Mock())
             self.assertEqual(
-                result.get("Metrics.Registries"),
+                result,
                 metrics.FREEAPPS_METRICS_REGISTRY,
             )


### PR DESCRIPTION
With metrics via micrometer, we should be able to configure any registries as detailed in the [Mendix docs](https://docs.mendix.com/refguide/metrics/#registries-configuration). 

However, a regression was causing additional registries like prometheus from being added. This PR fixes the regression.