### PR TITLE
Optionally enable TLSv1.0 and TLSv1.1 for outgoing requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,14 @@ Configure the `JAVA_OPTS` environment variable by using the `cf set-env` command
 cf set-env <YOUR_APP> JAVA_OPTS '["-Djava.rmi.server.hostname=127.0.0.1", "-Dcom.sun.management.jmxremote.authenticate=false", "-Dcom.sun.management.jmxremote.ssl=false", "-Dcom.sun.management.jmxremote.port=5000", "-Dcom.sun.management.jmxremote.rmi.port=5000"]'
 ```
 
+### Enabling TLSv1.0 and TLSv1.1 for Outgoing Connections
+
+OpenJDK switched off the insecure / End-of-Life TLSv1.0 and TLSv1.1 protocols for outgoing connections by default in April 2021. Since the buildpack uses an OpenJDK distribution, these protocols are also disabled by default for the buildpack.
+
+To re-enable TLSv1.0 and TLSv1.1 for outgoing connections, set the `ENABLE_OUTGOING_TLS_10_11` environment variable to `true`, and **restage** your application.
+
+**Enabling TLSv1.0 and TLSv1.1 for outgoing connections is at your own risk, and this functionality may disappear at any time.**
+
 ### Configuring Custom Runtime Settings
 
 To configure any of the advanced [Custom Runtime Settings](https://docs.mendix.com/refguide/custom-settings) you can use setting name prefixed with `MXRUNTIME_` as an environment variable.

--- a/tests/unit/test_java_tls10_11.py
+++ b/tests/unit/test_java_tls10_11.py
@@ -1,0 +1,110 @@
+import os, tempfile
+
+from unittest import TestCase, mock
+
+from buildpack.core.java import (
+    _configure_outgoing_tls_10_11,
+    _get_security_properties_file,
+    _get_major_version,
+    ENABLE_OUTGOING_TLS_10_11_KEY,
+)
+
+
+class TestJavaEnableTLSv10TLSv11(TestCase):
+    JAVA_SECURITY_PROPERTIES_CASES = [
+        (
+            r"""
+jdk.tls.disabledAlgorithms=SSLv3, TLSv1, TLSv1.1, RC4, DES, MD5withRSA, \
+DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, \
+include jdk.disabled.namedCurves
+    """,
+            r"""
+jdk.tls.disabledAlgorithms=SSLv3, RC4, DES, MD5withRSA, \
+DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, \
+include jdk.disabled.namedCurves
+    """,
+        ),
+        (
+            r"""
+jdk.tls.disabledAlgorithms=SSLv3, RC4, DES, MD5withRSA, \
+DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, TLSv1, TLSv1.1, \
+include jdk.disabled.namedCurves
+    """,
+            r"""
+jdk.tls.disabledAlgorithms=SSLv3, RC4, DES, MD5withRSA, \
+DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, \
+include jdk.disabled.namedCurves
+    """,
+        ),
+        (
+            r"""
+jdk.tls.disabledAlgorithms=SSLv3, RC4, DES, MD5withRSA, TLSv1, TLSv1.1
+    """,
+            r"""
+jdk.tls.disabledAlgorithms=SSLv3, RC4, DES, MD5withRSA
+    """,
+        ),
+    ]
+
+    @mock.patch.dict(
+        os.environ,
+        {ENABLE_OUTGOING_TLS_10_11_KEY: "true"},
+        clear=True,
+    )
+    def test_disable_tls10_11(self):
+        for case in self.JAVA_SECURITY_PROPERTIES_CASES:
+            security_properties_file = tempfile.NamedTemporaryFile()
+
+            with open(security_properties_file.name, "w+") as f:
+                f.writelines(case[0])
+
+            with mock.patch(
+                "buildpack.core.java._get_security_properties_file",
+                mock.MagicMock(return_value=security_properties_file.name),
+            ):
+                _configure_outgoing_tls_10_11("", {})
+
+            result = ""
+            with open(security_properties_file.name, "r+") as f:
+                result = "".join(f.readlines())
+
+            assert result.strip() == case[1].strip()
+
+    SECURITY_PROPERTIES_FILES_PATHS_CASES = [
+        (8, "lib"),
+        (11, "conf"),
+        (7, ""),
+        (13, "conf"),
+    ]
+
+    def test_security_properties_file(self):
+        for case in self.SECURITY_PROPERTIES_FILES_PATHS_CASES:
+            if case[1] == "":
+                with self.assertRaises(ValueError):
+                    _get_security_properties_file(
+                        "", {"version": str(case[0])}
+                    )
+            else:
+                file = _get_security_properties_file(
+                    "", {"version": str(case[0])}
+                )
+                assert case[1] in str(file)
+
+    MAJOR_VERSION_TEST_CASES = [
+        ("8", 8),
+        ("1.8.0", 8),
+        ("8u332", 8),
+        ("11", 11),
+        ("11.0.15", 11),
+        ("7", ""),
+        ("13.0.15", 13),
+    ]
+
+    def test_get_major_version(self):
+        for case in self.MAJOR_VERSION_TEST_CASES:
+            if case[1] == "":
+                with self.assertRaises(ValueError):
+                    _get_major_version({"version": case[0]})
+            else:
+                result = _get_major_version({"version": case[0]})
+                assert result == case[1]


### PR DESCRIPTION
OpenJDK disabled the **TLSv1.0 and TLSv1.1** protocols in March 2021 for outgoing connections. These protocols are generally considered to be **insecure** and **End-of-Life (EOL)**.

The Mendix runtime runs on the Java Virtual Machine (JVM). The latest updates to Java (#527, #530) upgraded the OpenJDK distribution in the buildpack (Adoptium) to versions which were released after March 2021. Therefore, outgoing connections from the Mendix runtime in the buildpack **cannot use TLSv1.0 and TLSv1.1 by default**.

 This PR adds an **option to re-enable these protocols**. To do so, set the `ENABLE_OUTGOING_TLS_10_11` environment variable to `true` and re-stage your application. As a result of enabling this environment variable, the Java security properties will be modified to allow these protocols.

**Using this option is at your own risk.**