### PR TITLE
Improve workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,11 @@ name: Build
 
 on:
   workflow_call:
+    inputs:
+      skip_tests:
+        type: boolean
+        required: false
+        default: false
     outputs:
       version_tag:
         description: "Auto-generated semantic version tag"
@@ -12,20 +17,22 @@ on:
 
 jobs:
   get-version:
-    name: Determine semantic version
+    name: Get semantic versions
     runs-on: ubuntu-latest
     outputs:
-      version_tag: ${{ steps.semantic-version.outputs.version_tag }}
+      version_tag: ${{ steps.autogenerate-version.outputs.version_tag }}
       current_version_tag: ${{ steps.get-current-version.outputs.current_version_tag}}
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - id: get-current-version
+      - name: Get current version
+        id: get-current-version
         run: |
           CURRENT_VERSION_TAG=$(git tag --list --sort=-version:refname "v*" | head -n 1)
           echo "::set-output name=current_version_tag::${CURRENT_VERSION_TAG}"
-      - id: semantic-version
+      - name: Auto-generate future version
+        id: autogenerate-version
         uses: paulhatch/semantic-version@v4.0.3
         with:
           tag_prefix: "v"
@@ -42,11 +49,14 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: 3.6
+          cache: pip
       - name: Install Python requirements
         run: make install_requirements
       - name: Lint
+        if: ${{ inputs.skip_tests == 'false' }}
         run: make lint
       - name: Run unit tests
+        if: ${{ inputs.skip_tests == 'false' }}
         run: make test_unit
       - name: Build
         run: VERSION=${{ needs.get-version.outputs.version_tag }} make build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Check if workflow should be skipped
         id: skip-check
-        uses: fkirc/skip-duplicate-actions@master
+        uses: fkirc/skip-duplicate-actions@v3
         with:
           github_token: ${{ github.token }}
           paths_ignore: '["**.md", "dev/**"]'
@@ -24,6 +24,8 @@ jobs:
     needs: pre
     if: ${{ needs.pre.outputs.skip != 'true' && github.event.pull_request.merged }}
     uses: ./.github/workflows/build.yml
+    with:
+      skip_tests: true
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
@@ -78,8 +80,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git fetch origin master
-          git fetch origin develop
           git checkout develop
           git merge master --ff-only
-          git push origin develop
+          git push

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,14 +35,6 @@ jobs:
         with:
           name: dist
           path: dist
-      - name: Generate changelog
-        id: generate-changelog
-        uses: mikepenz/release-changelog-builder-action@v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          fromTag: ${{ needs.build.outputs.current_version_tag }}
-          toTag: ${{ github.base_ref }}
       - name: Create Github release
         id: create-release
         uses: actions/create-release@v1
@@ -51,11 +43,7 @@ jobs:
         with:
           tag_name: ${{ needs.build.outputs.version_tag }}
           release_name: "${{ needs.build.outputs.version_tag }}: ${{ github.event.pull_request.title }}"
-          body: |
-            ${{ github.event.pull_request.body }}
-            
-            ## Changelog
-            ${{ steps.generate-changelog.outputs.changelog }}
+          body: ${{ github.event.pull_request.body }}
           draft: true
           prerelease: false
       - name: Upload release asset

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - name: Check if workflow should be skipped
       id: skip-check
-      uses: fkirc/skip-duplicate-actions@master
+      uses: fkirc/skip-duplicate-actions@v3
       with:
         github_token: ${{ github.token }}
         paths_ignore: '["**.md", "dev/**", "LICENSE"]'
@@ -48,7 +48,7 @@ jobs:
         echo "::set-output name=matrix::${TEST}"
   integration-test:      
     needs: [build, setup-integration-tests]
-    name: Run test
+    name: Run integration tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -67,6 +67,7 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: 3.6
+        cache: pip
     - name: Install Python requirements
       run: make install_requirements
     - name: Install Cloud Foundry development tools

--- a/.github/workflows/veracodescan.yml
+++ b/.github/workflows/veracodescan.yml
@@ -1,30 +1,34 @@
 name: Scan with Veracode
 
 on:
-  workflow_run:
-    workflows: ["Deploy to Github Releases"]
-    types:
-      - completed
+  pull_request:
+    types: [closed]
+    branches:
+      - master
 
 jobs:
+  build:
+    name: Build
+    uses: ./.github/workflows/build.yml
+    with:
+      skip_tests: true
   veracode-scan:
     name: Perform scan
     runs-on: ubuntu-latest
+    needs: build
     steps:
-      - name: Download PR artifact
-        uses: dawidd6/action-download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
-          workflow: deploy.yml
-          branch: master
           name: dist
+          path: dist
       - name: Upload and scan
         uses: veracode/veracode-uploadandscan-action@master
+        continue-on-error: true
         with:
-          filepath: 'cf-mendix-buildpack.zip'
-          vid: '${{ secrets.VERACODE_API_ID }}'
-          vkey: '${{ secrets.VERACODE_API_KEY }}'
-          appname: '${{ secrets.VERACODE_APP_NAME }}'
-          sandboxid: '${{ secrets.VERACODE_SANDBOX_ID }}'
+          filepath: dist/cf-mendix-buildpack.zip
+          vid: ${{ secrets.VERACODE_API_ID }}
+          vkey: ${{ secrets.VERACODE_API_KEY }}
+          appname: ${{ secrets.VERACODE_APP_NAME }}
+          sandboxid: ${{ secrets.VERACODE_SANDBOX_ID }}
           scantimeout: 15
-          criticality: 'VeryLow'
-          
+          criticality: VeryLow

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,9 @@ The following guidelines apply to releases and hotfixes:
 
 After a release or hotfix PR is merged to `master`, a draft release is created automatically. Be sure to:
 
-* **"Undraft"** the release to release it.
+* **Edit** the draft release:
+  * Press the magic [**"Automatically generate changelog"** button](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#creating-automatically-generated-release-notes-for-a-new-release) to include the changelog
+  * Release the release, i.e. **"undraft"** it
 * For a hotfix:
   * **Delete** your release or hotfix branch.
   * If the automated backmerge from `master` into `develop` did not work, ensure that the changes from `master` are merged or rebased into `develop`, and **force push** it to ensure that the hotfix changes are in `develop`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,11 +56,11 @@ The following guidelines apply to releases and hotfixes:
 
 0. Ensure that you are merging `develop` to `master` (release), or that your branch is based on `master` (hotfix).
 1. Ask at least one person to review the PR. This review counts as a release approval; in the case of a release, this is a formality.
-2. Merge to `master` using the **"Rebase and Merge"** strategy.
+2. Merge to `master` using the **"Merge Commit"** strategy.
 
 After a release or hotfix PR is merged to `master`, a draft release is created automatically. Be sure to:
 
 * **"Undraft"** the release to release it.
 * For a hotfix:
   * **Delete** your release or hotfix branch.
-  * If the automated backmerge from `master` into `develop` did not work, **rebase** `master` on `develop`, and **force push** it to ensure that the hotfix changes are in `develop`.
+  * If the automated backmerge from `master` into `develop` did not work, ensure that the changes from `master` are merged or rebased into `develop`, and **force push** it to ensure that the hotfix changes are in `develop`.


### PR DESCRIPTION
This PR includes the following changes to the Github Actions workflows:
* Change from rebase to merge commit strategy for changes to master
* Remove automated changelog generation in favour of the [native Github functionality](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#creating-automatically-generated-release-notes-for-a-new-release)
* Introduce skip tests option for build workflow
* Add cache to Python steps
* Add build step to Veracode scan workflow
* Various small naming changes