### PR TITLE
Add CycloneDX SBOM generation to dependency management

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -214,13 +214,14 @@ Dependencies can also be retrieved individually, as dependency information could
 
 #### Special / Reserved Fields
 
-The `artifact`, `alias` and `name` fields in a dependency object are reserved / special fields:
+A number of fields in a dependency object are reserved / special fields:
 
 * `artifact` should always be present and contains the location of the artifact that should be downloaded
 * `alias` contains alternative names for the artifact and is used to delete other / older versions from the Cloud Foundry cache for the application. It is not part of the dependency matrix, and can be a list of strings or a string value.
 * `name` contains the list of YAML sections that compose the dependency key. It is not part of the dependency matrix.
 * `managed` indicates whether the source of the dependency is managed by the authors of this buildpack
 * `*_key` fields contain the key of dictionary fields which are recursed into the dependency graph leaf nodes. See [here](#advanced-examples) for an example.
+* `cpe`, `purl` and `bom_*` fields contain information to generate a [Software Bill of Materials (SBOM)](#generating-an-sbom-for-external-dependencies).
 
 All other fields are free format.
 
@@ -321,6 +322,21 @@ To print a list of all managed external dependencies, run the following command:
 ```shell
 make list_external_dependencies
 ```
+
+#### Generating an SBOM for External Dependencies
+
+For some use cases, an official Software Bill of Materials (SBOM) is required. The following command generates a [CycloneDX](https://cyclonedx.org/) 1.4 JSON SBOM:
+
+```shell
+make generate_software_bom
+```
+
+An essential part of every SBOM is including identifiers for dependencies. Currently, there are two identifiers supported in the following fields:
+
+* `cpe`: Common Platform Enumeration (CPE) identifier. NIST maintains a [list of CPEs](https://nvd.nist.gov/products/cpe) to which vulnerabilities can be linked.
+* `purl`: Package URL (PURL). This specification can be found [here](https://github.com/package-url/purl-spec).
+
+Additionally, extra information can be included in the BOM, or override existing information. To do so, include a `bom_<key>` field, with `key` being the name of the information you are trying to add and override. The SBOM will contain this information, minus the `bom_` prefix.
 
 ### Vendoring External Dependencies
 

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ copy_vendored_dependencies:
 list_external_dependencies:
 	@python3 buildpack/util.py list-external-dependencies
 
+.PHONY: generate_software_bom
+generate_software_bom:
+	@python3 buildpack/util.py generate-software-bom
+
 .PHONY: download_wheels
 download_wheels: requirements
 	rm -rf build/vendor/wheels

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -37,6 +37,10 @@ dependencies:
         - AdoptOpenJDK-{{ type }}
         - "{{ type }}"
       artifact: "{{ vendor }}-{{ type }}-{{ version }}-linux-x64.tar.gz"
+      bom_type: framework
+      bom_version: "{{ version if version_key != '8' else '1.8.0.' + version.split('u')[1] }}"
+      cpe: cpe:2.3:a:oracle:jdk:{{ version if version_key != "8" else "1.8.0" }}:{{ "*" if version_key != "8" else "update" + version.split("u")[1] }}:*:*:*:*:*:*
+      purl: pkg:generic/{{ vendor|lower }}-{{ type }}@{{ version if version_key != "8" else "1.8.0." + version.split("u")[1] }}?arch=amd64
       type:
         - jre
         - jdk
@@ -66,6 +70,8 @@ dependencies:
   mono:
     "{{ version_key }}-{{ type }}":
       artifact: mono/mono-{{ version }}-mx-ubuntu-{{ type }}.tar.gz
+      bom_type: framework
+      cpe: cpe:2.3:a:mono-project:mono:{{ version }}:*:*:*:*:*:*:*
       type:
         - bionic
       version:
@@ -79,6 +85,7 @@ dependencies:
   nginx:
     artifact: nginx_{{ version }}_linux_x64_cflinuxfs3_{{ commit }}.tgz
     commit: f0918d6b
+    cpe: cpe:2.3:a:f5:nginx:{{ version }}:*:*:*:*:*:*:*
     version: 1.21.1
   telegraf:
     agent:


### PR DESCRIPTION
This PR adds [CycloneDX](https://cyclonedx.org/) Software Bill of Materials (SBOM) generation to the external dependency management logic.

The resulting SBOM can be used in vulnerability / security scans.