### PR TITLE
LM-850 AppDynamics node name fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,7 +548,7 @@ Please note that AppDynamics requires Mendix 7.15 or higher.
 | `APPDYNAMICS_AGENT_TIER_NAME`          | `<env_id>`                                                              | App Environment UUID       | How a tier is displayed on the Controller UI     |
 
 
-\* The `APPDYNAMICS_AGENT_NODE_NAME` environment variable will be appended with the value of the `CF_INSTANCE_ID` variable. If you use `node` for `APPDYNAMICS_AGENT_NODE_NAME` , the AppDynamics agent will be configured as `node_0` for instance `0` and `node_1` for instance `1` , etc.
+\* The `APPDYNAMICS_AGENT_NODE_NAME` environment variable will be appended with the value of the `CF_INSTANCE_ID` variable. If you use `node` for `APPDYNAMICS_AGENT_NODE_NAME` , the AppDynamics agent will be configured as `node-0` for instance `0` and `node-1` for instance `1` , etc.
 
 For more details about nodes and tiers: [Tiers and Nodes](https://docs.appdynamics.com/22.1/en/application-monitoring/tiers-and-nodes).
 

--- a/buildpack/telemetry/appdynamics.py
+++ b/buildpack/telemetry/appdynamics.py
@@ -25,7 +25,7 @@ APPDYNAMICS_ENV_VARS = {
         "APPDYNAMICS_AGENT_APPLICATION_NAME",
         default=util.get_app_from_domain(),
     ),
-    "APPDYNAMICS_AGENT_NODE_NAME": "{}_{}".format(
+    "APPDYNAMICS_AGENT_NODE_NAME": "{}-{}".format(
         os.getenv("APPDYNAMICS_AGENT_NODE_NAME", default="node"),
         CF_APPLICATION_INDEX,
     ),
@@ -38,7 +38,7 @@ APPDYNAMICS_ENV_VARS = {
     "APPDYNAMICS_CONTROLLER_SSL_ENABLED": os.getenv(
         "APPDYNAMICS_CONTROLLER_SSL_ENABLED", default="true"
     ),
-    "APPDYNAMICS_AGENT_UNIQUE_HOST_ID": "{}_{}".format(
+    "APPDYNAMICS_AGENT_UNIQUE_HOST_ID": "{}-{}".format(
         os.getenv(
             "APPDYNAMICS_AGENT_UNIQUE_HOST_ID", default=CF_APPLICATION_NAME
         ),


### PR DESCRIPTION
Naming format for NODE is changed:

Underscore replaced for dash according to AppDynamics naming convention.

Old format: node_0
New format: node-1

The same change is relevant to Unique Host Id name. 