### PR TITLE
Added trends forwarder support

### DIFF
--- a/buildpack/telemetry/metrics.py
+++ b/buildpack/telemetry/metrics.py
@@ -128,6 +128,26 @@ def get_appmetrics_target():
     return os.getenv("APPMETRICS_TARGET")
 
 
+def get_micrometer_metrics_url():
+    """
+    This function is used to provide selection of the trends storage URL.
+    There are two options - URL of trends-storage-server (old trends stack),
+    or URL of trends-forwarder (new trends stack). This selection is relevant for
+    micrometer metrics only. Runtime version 9.7 and above is required.
+
+    """
+    use_trends_forwarder = strtobool(
+        os.getenv("USE_TRENDS_FORWARDER", default="false")
+    )
+
+    trends_forwarder_url = os.getenv("TRENDS_FORWARDER_URL", default="")
+
+    if use_trends_forwarder and trends_forwarder_url:
+        return trends_forwarder_url
+    else:
+        return get_metrics_url()
+
+
 def get_metrics_url():
     return os.getenv("TRENDS_STORAGE_URL")
 
@@ -151,9 +171,9 @@ def _micrometer_runtime_requirement(runtime_version):
 
 def micrometer_metrics_enabled(runtime_version):
     """Check for metrics from micrometer."""
-    return bool(get_metrics_url()) and _micrometer_runtime_requirement(
-        runtime_version
-    )
+    return bool(
+        get_micrometer_metrics_url()
+    ) and _micrometer_runtime_requirement(runtime_version)
 
 
 def configure_metrics_registry(m2ee):

--- a/buildpack/telemetry/telegraf.py
+++ b/buildpack/telemetry/telegraf.py
@@ -239,7 +239,7 @@ def update_config(m2ee, app_name):
         datadog_api_key=datadog.get_api_key(),
         datadog_api_url="{}series/".format(datadog.get_api_url()),
         http_outputs=_get_http_outputs(),
-        trends_storage_url=metrics.get_metrics_url(),
+        trends_storage_url=metrics.get_micrometer_metrics_url(),
         micrometer_metrics=metrics.micrometer_metrics_enabled(runtime_version),
         cf_instance_index=_get_app_index(),
         app_name=app_name,

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -6,3 +6,4 @@ pylint==2.9.6
 pyopenssl==20.0.1
 randomname==0.1.5
 requests-mock==1.9.3
+parameterized==0.8.1

--- a/tests/unit/test_micrometer_metrics.py
+++ b/tests/unit/test_micrometer_metrics.py
@@ -6,6 +6,7 @@ from lib.m2ee.version import MXVersion
 
 from unittest import TestCase
 from unittest.mock import Mock, patch
+from parameterized import parameterized
 
 
 class TestMicrometerMetrics(TestCase):
@@ -15,6 +16,31 @@ class TestMicrometerMetrics(TestCase):
             "buildpack.telemetry.metrics.get_metrics_url",
             return_value="non_empty_url",
         ).start()
+
+    @parameterized.expand(
+        [
+            ["false", "dummy_forwarder_url", "non_empty_url"],
+            ["false", "", "non_empty_url"],
+            ["true", "", "non_empty_url"],
+            ["true", "dummy_forwarder_url", "dummy_forwarder_url"],
+        ]
+    )
+    def test_get_micrometer_metrics_url(
+        self,
+        use_trends_forwarder,
+        trends_forwarder_url,
+        expected_url,
+    ):
+        with patch.dict(
+            os.environ,
+            {
+                "USE_TRENDS_FORWARDER": use_trends_forwarder,
+                "TRENDS_FORWARDER_URL": trends_forwarder_url,
+            },
+        ):
+
+            url = metrics.get_micrometer_metrics_url()
+            self.assertEqual(url, expected_url)
 
     def test_old_runtime_forced_to_disable(self):
         with patch.dict(os.environ, {"DISABLE_MICROMETER_METRICS": "true"}):


### PR DESCRIPTION
Micrometer metrics are pushed to trends-forwarder service instead of trends-storage-server if corresponding feature flag is set.   