### PR TITLE
Use trends-forwarder by default instead of trends-storage-server for micrometer

### DIFF
--- a/buildpack/telemetry/metrics.py
+++ b/buildpack/telemetry/metrics.py
@@ -137,7 +137,7 @@ def get_micrometer_metrics_url():
 
     """
     use_trends_forwarder = strtobool(
-        os.getenv("USE_TRENDS_FORWARDER", default="false")
+        os.getenv("USE_TRENDS_FORWARDER", default="true")
     )
 
     trends_forwarder_url = os.getenv("TRENDS_FORWARDER_URL", default="")


### PR DESCRIPTION
As we are rolling out new trends stack we should make USE_TRENDS_FORWARDER true by default.