### PR TITLE
configure max_metaspace_size as env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Release notes are available for the [buildpack](https://github.com/mendix/cf-men
 - [Java Configuration](#java-configuration)
   - [Java Version](#java-version)
   - [Java Heap Size](#java-heap-size)
+  - [Java Max Metaspace Size](#java-max-metaspace-size)
   - [Java Virtual Machine (JVM) Settings](#java-virtual-machine-jvm-settings)
   - [Certificate Authorities](#certificate-authorities)
 - [Built-In Proxy Configuration](#built-in-proxy-configuration)
@@ -435,6 +436,14 @@ The Java heap size is configured automatically based on best practices. You can 
 ```shell
 cf set-env <YOUR_APP> HEAP_SIZE 512M
 ```
+### Java Max Metaspace Size
+
+The Java Max Metaspace Size is configured automatically based on best practices. You can tweak this to your needs by using another environment variable, in which case it is used directly.
+
+```shell
+cf set-env <YOUR_APP> MAX_METASPACE_SIZE 512M
+```
+
 
 ### Java Virtual Machine (JVM) Settings
 

--- a/buildpack/core/java.py
+++ b/buildpack/core/java.py
@@ -305,6 +305,10 @@ def _set_jvm_memory(m2ee, vcap):
     heap_size = str(heap_size) + "M"
 
     env_heap_size = os.environ.get("HEAP_SIZE")
+    max_metaspace_size = os.getenv("MAX_METASPACE_SIZE", "256M")
+    
+    util.upsert_javaopts(m2ee, "-XX:MaxMetaspaceSize=%s" % max_metaspace_size)
+
     if env_heap_size:
         if int(env_heap_size[:-1]) < limit:
             heap_size = env_heap_size
@@ -318,8 +322,6 @@ def _set_jvm_memory(m2ee, vcap):
 
     util.upsert_javaopts(m2ee, "-Xmx%s" % heap_size)
     util.upsert_javaopts(m2ee, "-Xms%s" % heap_size)
-
-    util.upsert_javaopts(m2ee, "-XX:MaxMetaspaceSize=256M")
 
     logging.debug("Java heap size set to %s", heap_size)
 


### PR DESCRIPTION
We may want to add the possibility to manually change the XX:MaxMetaspaceSize value for some customers.