### PR TITLE
Update mendix-logfilter dependency to v0.0.2

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -53,7 +53,8 @@ dependencies:
         - "11": 11.0.15
   logs:
     mendix-logfilter:
-      artifact: logs/mendix-logfilter.tar.gz
+      artifact: logs/mendix-logfilter-{{version}}.tar.gz
+      version: 0.0.2
   mendix:
     mx-agent:
       artifact: mx-agent/mx-agent-v{{ version }}.jar


### PR DESCRIPTION
This fixes the log truncation issue with log messages that start with digits.

For instance, before the fix texts like:
`123 : some message` ends up as `some message` and we lose the initial digits.