### PR TITLE
Pass through micrometer and metric_type tags

### DIFF
--- a/etc/telegraf/telegraf.toml.j2
+++ b/etc/telegraf/telegraf.toml.j2
@@ -334,9 +334,8 @@
   data_format = "json"
   json_timestamp_units = "1ns"
 
-  # tagexlude drops the custom tag set for micrometer metrics
-  # and any other non-relevant tags
-  tagexclude = ["micrometer_metrics", "host", "metric_type"]
+  # tagexlude drops any non-relevant tags
+  tagexclude = ["host"]
 
   ## Additional HTTP headers
   [outputs.http.headers]


### PR DESCRIPTION
Allow the following tags to be forwarded along with the metrics to the trends backend : 
- `micrometer_metrics`
- `metric_type`

This allows the backend to know the source of the metric if it is originating from the newer runtimes using the micrometer library or the older runtimes.