### PR TITLE
Upgrade datadog buildpack

### DIFF
--- a/buildpack/telemetry/datadog.py
+++ b/buildpack/telemetry/datadog.py
@@ -398,9 +398,6 @@ def _set_up_environment(model_version, runtime_version):
     e["DD_LOGS_ENABLED"] = "true"
     e["DD_ENABLE_CHECKS"] = str(bool(_is_checks_enabled())).lower()
     e["LOGS_CONFIG"] = json.dumps(_get_logging_config())
-    e[
-        "SUPPRESS_DD_AGENT_OUTPUT"
-    ] = "false"  # Has to be set explicitly since DD buildpack 4.22.0
 
     return e
 

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -20,7 +20,7 @@ dependencies:
     buildpack:
       alias: cf-datadog-sidecar
       artifact: datadog/datadog-cloudfoundry-buildpack-{{ version }}.zip
-      version: 4.33.0
+      version: 4.35.1
     trace-agent:
       artifact: datadog/dd-java-agent-{{ version }}.jar
       version: 0.101.0


### PR DESCRIPTION
Bump the datadog-cloudfoundry-buildpack version from 4.33.0 to [4.35.1](https://github.com/DataDog/datadog-cloudfoundry-buildpack/releases/tag/4.35.1).
This bumps the embedded Datadog Agent version to 7.41.1.