### PR TITLE
Add telegraf file output for debugging purposes

### DIFF
--- a/buildpack/telemetry/telegraf.py
+++ b/buildpack/telemetry/telegraf.py
@@ -270,6 +270,7 @@ def update_config(m2ee, app_name):
         dynatrace_enabled=dynatrace.is_telegraf_enabled(),
         dynatrace_config=_get_dynatrace_config(app_name),
         telegraf_debug_enabled=os.getenv("TELEGRAF_DEBUG_ENABLED", "false"),
+        telegraf_fileout_enabled=strtobool(os.getenv("TELEGRAF_FILEOUT_ENABLED", "false"))
     )
 
     logging.debug("Writing Telegraf configuration file...")

--- a/etc/telegraf/telegraf.toml.j2
+++ b/etc/telegraf/telegraf.toml.j2
@@ -370,5 +370,36 @@
   [outputs.http.tagpass]
   micrometer_metrics = ["true"]
 
+{% if telegraf_fileout_enabled %}
+[[outputs.file]]
+  ## Files to write to, "stdout" is a specially handled file.
+  files = ["/app/log/metrics.out"]
+
+  ## The file will be rotated after the time interval specified.  When set
+  ## to 0 no time based rotation is performed.
+  rotation_interval = "12h"
+
+  ## The logfile will be rotated when it becomes larger than the specified
+  ## size.  When set to 0 no size based rotation is performed.
+  # rotation_max_size = "0MB"
+
+  ## Maximum number of rotated archives to keep, any older logs are deleted.
+  ## If set to -1, no archives are removed.
+  rotation_max_archives = 5
+
+  ## Data format to output.
+  ## Each data format has its own unique set of configuration options, read
+  ## more about them here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
+  data_format = "influx"
+
+  # tagexlude drops any non-relevant tags
+  tagexclude = ["host"]
+
+  # Pass only those metrics that has below tag set
+  [outputs.file.tagpass]
+  micrometer_metrics = ["true"]
+
+{% endif %}
 ####################################################################################
 {% endif %}


### PR DESCRIPTION
This PR introduces a new environment variable `TELEGRAF_FILEOUT_ENABLED`, which if enabled, logs all the metrics published by the runtime to a file on disk.