### PR TITLE
Hotfix: Revert DD buildpack version to 4.33.0

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -20,7 +20,7 @@ dependencies:
     buildpack:
       alias: cf-datadog-sidecar
       artifact: datadog/datadog-cloudfoundry-buildpack-{{ version }}.zip
-      version: 4.35.1
+      version: 4.33.0
     trace-agent:
       artifact: datadog/dd-java-agent-{{ version }}.jar
       version: 0.101.0


### PR DESCRIPTION
Hot fix. Revert the version of DD buildpack to 4.33.0.