### PR TITLE
Metadata for SPLUNK Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,7 +582,10 @@ To enable New Relic, simply bind a New Relic service to this app and settings wi
 
 ### Splunk
 
-To collect Mendix Runtime logs to [Splunk Cloud Platform](https://www.splunk.com/en_us/products/splunk-cloud-platform.html), [Fluent Bit](https://docs.fluentbit.io/manual/) is used.
+#### Set up Splunk integration
+
+To collect Mendix Runtime logs to [Splunk Cloud Platform](https://www.splunk.com/en_us/products/splunk-cloud-platform.html), 
+[Fluent Bit](https://docs.fluentbit.io/manual/) is used.
 
 To enable Splunk integration for a Mendix application, following environment variables should be configured.
 
@@ -600,6 +603,26 @@ button `New Token` in the top-right corner of the page.
 
 Once the Mendix application is redeployed/restarted, the runtime application logs should appear on the Splunk Cloud under `Search & Reporting`.
 In the search line specify: `source="http:your_token_name"`, click search button.
+
+#### Metadata
+
+In addition to the runtime application logs, the following JSON-formatted metadata is automatically sent to the Splunk Cloud Platform:
+
+* `environment_id` - unique identifier of the environment;
+* `instance_index` - number of the application instance;
+* `hostname` - name of the application host;
+* `application_name` - default application name, retrieved from domain name;
+* `model_version` - model version of the Mendix runtime;
+* `runtime_version` - version of the Mendix runtime.
+
+You can filter the data by these fields on Splunk Cloud Platform web interface.
+
+#### Custom tags
+
+You can also set up custom tags in the following format `key:value`. We recommend that you add the following custom tags:
+
+* `app:{app_name}` – this enables you to identify all logs sent from your app (for example, **app:customermanagement**)
+* `env:{environment_name}` – this enables you to identify logs sent from a particular environment so you can separate out production logs from test logs (for example, **env:accp**)
 
 ### AppDynamics
 

--- a/buildpack/start.py
+++ b/buildpack/start.py
@@ -174,7 +174,7 @@ if __name__ == "__main__":
         # Start components and runtime
         telegraf.run(runtime_version)
         datadog.run(model_version, runtime_version)
-        fluentbit.run()
+        fluentbit.run(model_version, runtime_version)
         metering.run()
         logs.run(m2ee)
         runtime.run(m2ee, logs.get_loglevels())

--- a/etc/fluentbit/fluentbit.conf
+++ b/etc/fluentbit/fluentbit.conf
@@ -10,6 +10,12 @@
     script  redaction.lua
     call    apply_redaction
 
+[FILTER]
+    Name    lua
+    Match   *
+    script  metadata.lua
+    call    add_metadata
+
 [OUTPUT]
     # SPLUNK cloud platform
     Name        splunk

--- a/etc/fluentbit/metadata.lua
+++ b/etc/fluentbit/metadata.lua
@@ -1,0 +1,25 @@
+function add_metadata(tag, timestamp, record)
+
+    record["instance_index"] = os.getenv("CF_INSTANCE_INDEX") or ""
+    record["environment_id"] = os.getenv("ENVIRONMENT") or ""
+    record["hostname"] = os.getenv("SPLUNK_APP_HOSTNAME") or ""
+    record["application_name"] = os.getenv("SPLUNK_APP_NAME") or ""
+    record["runtime_version"] = os.getenv("SPLUNK_APP_RUNTIME_VERSION") or ""
+    record["model_version"] = os.getenv("SPLUNK_APP_MODEL_VERSION") or ""
+
+    local raw_tags = os.getenv("TAGS")
+    if raw_tags then
+        local tags_with_quotes = raw_tags:sub(2, raw_tags:len()-1)
+        local str_tags = tags_with_quotes:gsub('"','')
+
+        for item in str_tags:gmatch("([^,]+)") do
+            for key, val in item:gmatch("([^:]*):?([^:]*)") do
+                if (key and (key:gsub(' ','') ~= "")) then
+                    record[key] = val
+                end
+            end
+        end
+    end
+
+    return 2, timestamp, record
+end


### PR DESCRIPTION
This update is relevant for customers who use Splunk Cloud Platform integration.
New fields (metadata) have been added.
In addition to the runtime application logs, the following JSON-formatted metadata is automatically sent to the Splunk Cloud Platform:

* `environment_id`
* `instance_index`
* `hostname`
* `application_name`
* `model_version`
* `runtime_version` 

Also, it is possible to send custom key-value tags, defined via Developer Portal. 