### PR TITLE
Route telegraf logs to a file instead of STDERR

### DIFF
--- a/etc/telegraf/telegraf.toml.j2
+++ b/etc/telegraf/telegraf.toml.j2
@@ -380,11 +380,11 @@
 
   ## The file will be rotated after the time interval specified.  When set
   ## to 0 no time based rotation is performed.
-  rotation_interval = "12h"
+  # rotation_interval = "12h"
 
   ## The logfile will be rotated when it becomes larger than the specified
   ## size.  When set to 0 no size based rotation is performed.
-  # rotation_max_size = "0MB"
+  rotation_max_size = "10MB"
 
   ## Maximum number of rotated archives to keep, any older logs are deleted.
   ## If set to -1, no archives are removed.

--- a/etc/telegraf/telegraf.toml.j2
+++ b/etc/telegraf/telegraf.toml.j2
@@ -16,7 +16,10 @@
     flush_jitter = "5s"
     precision = ""
     debug = {{ telegraf_debug_enabled }}
-    logfile = ""
+    logtarget = "file"
+    logfile = "/app/log/telegraf.log"
+    logfile_rotation_max_size = "10MB"
+    logfile_rotation_max_archives = 5
     hostname = "{{ hostname }}"
     omit_hostname = false
 


### PR DESCRIPTION
`Telegraf` is part of the application metrics pipeline and this change is mainly to suppress telegraf-related warnings and errors from customer logs. 

However, as we still need them for troubleshooting purposes, we route it to a file on disk with logrotate enabled.