### PR TITLE
Route `mx_runtime_user_login` metric to trends stack via a separate stream

### DIFF
--- a/buildpack/telemetry/metrics.py
+++ b/buildpack/telemetry/metrics.py
@@ -45,12 +45,12 @@ INFLUX_REGISTRY = {
             "values": ["mx.runtime.user.login"],
         },
         # Filter out irrelevant metrics to reduce
-        # the payload size passed to TSS
+        # the payload size passed to TSS/TFR
         # https://docs.mendix.com/refguide/metrics#filters
         {
             "type": "nameStartsWith",
             "result": "deny",
-            "values": ["commons.pool"],
+            "values": ["commons.pool", "jvm.buffer"],
         },
     ],
 }

--- a/etc/telegraf/telegraf.toml.j2
+++ b/etc/telegraf/telegraf.toml.j2
@@ -363,6 +363,42 @@
   # tagexlude drops any non-relevant tags
   tagexclude = ["host"]
 
+  # Drop `mx_runtime_user_login` metrics
+  # We drop them as we don't want it to be part of
+  # the payload which is used for Cloud graphs
+  namedrop = ["mx_runtime_user_login"]
+
+  ## Additional HTTP headers
+  [outputs.http.headers]
+  Content-Type = "application/json"
+  # custom header field
+  Micrometer-Metrics = "true"
+
+  # Pass only those metrics that has below tag set
+  [outputs.http.tagpass]
+  micrometer_metrics = ["true"]
+
+[[outputs.http]]
+  # This http output is ONLY to send all the
+  #  `mx_runtime_user_login` metrics as a single payload
+  namepass = ["mx_runtime_user_login"]
+
+  ## URL is the address to send metrics to
+  url = "{{ trends_storage_url }}"
+
+  ## Timeout for HTTP message
+  timeout = "10s"
+
+  ## HTTP method, one of: "POST" or "PUT"
+  method = "POST"
+
+  ## Data format to output.
+  data_format = "json"
+  json_timestamp_units = "1ns"
+
+  # tagexlude drops any non-relevant tags
+  tagexclude = ["host"]
+
   ## Additional HTTP headers
   [outputs.http.headers]
   Content-Type = "application/json"
@@ -398,6 +434,11 @@
 
   # tagexlude drops any non-relevant tags
   tagexclude = ["host"]
+
+  # Drop `mx_runtime_user_login` metrics
+  # We drop them as we don't want it to be part of
+  # the payload which is used for Cloud graphs
+  namedrop = ["mx_runtime_user_login"]
 
   # Pass only those metrics that has below tag set
   [outputs.file.tagpass]

--- a/etc/telegraf/telegraf.toml.j2
+++ b/etc/telegraf/telegraf.toml.j2
@@ -347,6 +347,8 @@
   app_name = "{{ app_name }}"
 
 [[outputs.http]]
+  alias = "mx-trends-metrics"
+
   ## URL is the address to send metrics to
   url = "{{ trends_storage_url }}"
 
@@ -379,8 +381,11 @@
   micrometer_metrics = ["true"]
 
 [[outputs.http]]
-  # This http output is ONLY to send all the
-  #  `mx_runtime_user_login` metrics as a single payload
+  alias = "datalake-metrics"
+
+  # This http output is ONLY to send all the datalake metrics
+  # as a single payload. For instance;
+  #  `mx_runtime_user_login`
   namepass = ["mx_runtime_user_login"]
 
   ## URL is the address to send metrics to
@@ -388,6 +393,12 @@
 
   ## Timeout for HTTP message
   timeout = "10s"
+
+  # Higher flush interval and batch size, so that we
+  # don't bombard TFR and DataLake with too many requests, but
+  # few requests with bigger payloads
+  metric_batch_size = 3000
+  flush_interval = "30s"
 
   ## HTTP method, one of: "POST" or "PUT"
   method = "POST"

--- a/tests/integration/test_telegraf.py
+++ b/tests/integration/test_telegraf.py
@@ -93,7 +93,7 @@ class TestCaseTelegraf(basetest.BaseTest):
 
         # Ensure the trends-storage-url is set
         output = self.run_on_container(
-            "cat {} | grep -A2 outputs.http".format(telegraf_config_path)
+            "cat {} | grep -A5 outputs.http".format(telegraf_config_path)
         )
         assert output is not None
         assert str(output).find("some-fake-url") >= 0


### PR DESCRIPTION
This PR is more of an optimization of how Mendix collects application runtime metrics for Mendix Cloud graphs.

The change adds a separate telegraf output plugin just for the runtime login metrics as the volume
of these metrics could be quite large and result in metric buffer overflow.