### PR TITLE
APM metrics filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,7 +583,7 @@ Note that:
 
 ## Telemetry Configuration
 
-The buildpack includes a variety of telemetry agents, and can configure logging for the Mendix Runtime.
+The buildpack includes a variety of telemetry agents that can be configured to collect and forward metrics/logs from the Mendix Runtime.
 
 ### New Relic
 
@@ -828,6 +828,43 @@ Example (1000 loglines/second):
 ```shell
 cf set-env <YOUR_APP> LOG_RATELIMIT '1000'
 ```
+
+### Custom Runtime Metrics filtering
+
+For the third-party integrations explained above, in addition to the metrics collected by the agents, custom runtime metrics are provided via telegraf.
+This configuration also has a filtering mechanism that allows users to specify metrics they allow or deny for the vendor they are using.
+To filter the ingestion of custom runtime metrics to third party APMs, users should provide a list of prefixes of the metrics they want to allow/deny using the environment variables listed below.
+
+Note: Custom database metrics cannot be filtered by name, to turn them off, the `APPMETRICS_INCLUDE_DB` environment variable should be set to false. 
+
+#### APM_METRICS_FILTER_ALLOW
+
+Comma-separated list of prefixes for the metrics to be allowed. By default, all metrics are allowed, even if they are not specified via this env var.
+
+For example, to allow only the session metrics, `APM_METRICS_FILTER_ALLOW` should be set to `mx.runtime.stats.sessions`:
+
+```shell
+cf set-env <YOUR_APP> APM_METRICS_FILTER_ALLOW 'mx.runtime.stats.sessions'
+```
+
+#### APM_METRICS_FILTER_DENY
+
+Comma-separated list of prefixes for the metrics to be denied. 
+
+For example, to deny all metrics starting with jetty or mx.runtime, the environment variable should be set to `jetty,mx.runtime`:
+
+```shell
+cf set-env <YOUR_APP> APM_METRICS_FILTER_DENY 'jetty,mx.runtime'
+```
+
+#### APM_METRICS_FILTER_DENY_ALL
+
+If this environment variable is set to `true`, all metrics will be denied regardless of values of `APM_METRICS_FILTER_ALLOW`, `APM_METRICS_FILTER_DENY`, and `APPMETRICS_INCLUDE_DB`.
+
+```shell
+cf set-env <YOUR_APP> APM_METRICS_FILTER_DENY_ALL true
+```
+
 
 ## Using the Buildpack without an Internet Connection
 

--- a/buildpack/telemetry/telegraf.py
+++ b/buildpack/telemetry/telegraf.py
@@ -75,6 +75,8 @@ STATSD_PORT_ALT = 18125
 
 
 def include_db_metrics():
+    if metrics.deny_all_apm_metrics():
+        return False
     if util.is_free_app():
         # For free apps we are not interested in database metrics
         return False
@@ -169,7 +171,7 @@ def _get_http_outputs():
 
 
 def _get_db_config():
-    if (include_db_metrics() or datadog.get_api_key()) and util.is_cluster_leader():
+    if include_db_metrics() and util.is_cluster_leader():
         db_config = database.get_config()
         if db_config and db_config["DatabaseType"] == "PostgreSQL":
             return db_config

--- a/etc/telegraf/telegraf.toml.j2
+++ b/etc/telegraf/telegraf.toml.j2
@@ -430,7 +430,7 @@
   # Higher flush interval and batch size, so that we
   # don't bombard TFR and DataLake with too many requests, but
   # few requests with bigger payloads
-  metric_batch_size = 3000
+  metric_batch_size = 2500
   flush_interval = "30s"
 
   ## HTTP method, one of: "POST" or "PUT"


### PR DESCRIPTION
Add filtering capability for metrics ingestion to third-party APMs

APM_METRICS_FILTER_ALLOW and APM_METRICS_FILTER_DENY environment variables are introduced.

Also in telegraf configuration round_interval set to true for internal metrics