### PR TITLE
Bump Java versions

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -49,8 +49,8 @@ dependencies:
         - jdk
       vendor: Adoptium
       version:
-        - "8": 8u332
-        - "11": 11.0.16
+        - "8": 8u372
+        - "11": 11.0.18
   logs:
     mendix-logfilter:
       artifact: logs/mendix-logfilter-{{version}}.tar.gz

--- a/tests/unit/test_java_tls10_11.py
+++ b/tests/unit/test_java_tls10_11.py
@@ -90,7 +90,7 @@ jdk.tls.disabledAlgorithms=SSLv3, RC4, DES, MD5withRSA
     MAJOR_VERSION_TEST_CASES = [
         ("8", 8),
         ("1.8.0", 8),
-        ("8u332", 8),
+        ("8u372", 8),
         ("11", 11),
         ("11.0.15", 11),
         ("7", ""),


### PR DESCRIPTION
Though this doesn't resolve <https://bugs.openjdk.org/browse/JDK-8230305> for our cflinuxfs4 upgrade, it's still a good idea to go to the latest minor versions.