### PR TITLE
Emit metrics in telegraf for third-party integration usages

### DIFF
--- a/etc/telegraf/telegraf.toml.j2
+++ b/etc/telegraf/telegraf.toml.j2
@@ -28,18 +28,28 @@
 [[inputs.exec]]
     commands = ["echo {{ is_enabled }}"]
     name_override = "integration_usage"
-    # timeout = "5s"
-    interval = "20s" # for tests
+    interval = "6h"
     data_format = "value"
     data_type = "integer"
     [inputs.exec.tags]
         app_name = "{{ app_name }}"
         instance_index = "{{ cf_instance_index }}"
-        runtime_version = "{{ runtime_version }}"
         integration_name = "{{ integration_name }}"
         internal_metrics = "true"
-
 {% endfor %}
+
+# Separate metric for runtime_version
+[[inputs.exec]]
+    commands = ["echo {{ runtime_version }}"]
+    name_override = "runtime_version"
+    interval = "24h"
+    data_format = "value"
+    data_type = "string"
+    [inputs.exec.tags]
+        app_name = "{{ app_name }}"
+        instance_index = "{{ cf_instance_index }}"
+        internal_metrics = "true"
+
 
 {% if statsd_port and not datadog_api_key %}
 # StatsD input for Mendix Java Agent
@@ -333,7 +343,7 @@
 # The API token needs "Ingest metrics" scope permission.
     api_token = "{{ dynatrace_config['token'] }}"
 #
-# Ignore any metric with micrometer_metrics tag, since they meant for our TSS/TFR metrics path
+# Ignore any metric with micrometer_metrics or internal_metrics tags, since they meant for our TSS/TFR metrics path
     [outputs.dynatrace.tagdrop]
         micrometer_metrics = ["true"]
         internal_metrics = ["true"]

--- a/etc/telegraf/telegraf.toml.j2
+++ b/etc/telegraf/telegraf.toml.j2
@@ -23,6 +23,24 @@
     hostname = "{{ hostname }}"
     omit_hostname = false
 
+# Integration usage monitoring
+{% for integration_name, is_enabled in integration_usages.items() %}
+[[inputs.exec]]
+    commands = ["echo {{ is_enabled }}"]
+    name_override = "integration_usage"
+    # timeout = "5s"
+    interval = "20s" # for tests
+    data_format = "value"
+    data_type = "integer"
+    [inputs.exec.tags]
+        app_name = "{{ app_name }}"
+        instance_index = "{{ cf_instance_index }}"
+        runtime_version = "{{ runtime_version }}"
+        integration_name = "{{ integration_name }}"
+        internal_metrics = "true"
+
+{% endfor %}
+
 {% if statsd_port and not datadog_api_key %}
 # StatsD input for Mendix Java Agent
 [[inputs.statsd]]
@@ -261,6 +279,7 @@
     # Ignore any micrometer_metrics
     [outputs.datadog.tagdrop]
         micrometer_metrics = ["true"]
+        internal_metrics = ["true"]
 {% endif %}
 
 {% if http_outputs %}
@@ -283,6 +302,7 @@
     # from influxdb_listener plugin
     [outputs.http.tagdrop]
         micrometer_metrics = ["true"]
+        internal_metrics = ["true"]
 
 {% endfor %}
 {% endif %}
@@ -298,6 +318,7 @@
     # Ignore any micrometer_metrics
     [outputs.exec.tagdrop]
         micrometer_metrics = ["true"]
+        internal_metrics = ["true"]
 {% endif %}
 
 {% if dynatrace_enabled %}
@@ -312,9 +333,10 @@
 # The API token needs "Ingest metrics" scope permission.
     api_token = "{{ dynatrace_config['token'] }}"
 #
-# Ignore any micrometer_metrics
+# Ignore any metric with micrometer_metrics tag, since they meant for our TSS/TFR metrics path
     [outputs.dynatrace.tagdrop]
         micrometer_metrics = ["true"]
+        internal_metrics = ["true"]
 #
 # Optional dimensions to be added to every metric
     [outputs.dynatrace.default_dimensions]
@@ -379,6 +401,7 @@
   # Pass only those metrics that has below tag set
   [outputs.http.tagpass]
   micrometer_metrics = ["true"]
+  internal_metrics = ["true"]
 
 [[outputs.http]]
   alias = "datalake-metrics"
@@ -454,6 +477,7 @@
   # Pass only those metrics that has below tag set
   [outputs.file.tagpass]
   micrometer_metrics = ["true"]
+  internal_metrics = ["true"]
 
 {% endif %}
 ####################################################################################


### PR DESCRIPTION

* Use telegraf's exec plugin to emit metrics using the usage information of the integrations
* `internal_metrics` tag is introduced to be sure that these metrics are only routed to TSS/TFR stack
* `runtime_version` metric is also added since we were already thinking that it may be helpful for debugging in various cases
