### PR TITLE
Upgrade datadog buildpack to 4.35.1

### DIFF
--- a/buildpack/telemetry/datadog.py
+++ b/buildpack/telemetry/datadog.py
@@ -516,7 +516,7 @@ def _patch_run_datadog_script(script_dir):
         lines = file_handler.readlines()
         file_handler.seek(0)
         for line in lines:
-            if "stop_datadog &" in line:
+            if "monit_datadog &" in line:
                 file_handler.write(f"# {line}")
             else:
                 file_handler.write(line)

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -20,7 +20,7 @@ dependencies:
     buildpack:
       alias: cf-datadog-sidecar
       artifact: datadog/datadog-cloudfoundry-buildpack-{{ version }}.zip
-      version: 4.33.0
+      version: 4.35.1
     trace-agent:
       artifact: datadog/dd-java-agent-{{ version }}.jar
       version: 0.101.0


### PR DESCRIPTION
- Upgrade dd-cloudfoundry-buildpack from 4.33.0 -> 4.35.1
- Patch `run-datadog.sh` script to fix agent crashes

[datadog-cloudfoundry-buildpack](https://github.com/DataDog/datadog-cloudfoundry-buildpack) has a monitoring routine that assumes a multi-build pack setup and doesn't work well with our current DD setup. As a result, it stops all the agents if a certain process is not running. So patching the recently added [monit_datadog](https://github.com/DataDog/datadog-cloudfoundry-buildpack/commit/34d6eb21f52f4d4a9c1c06b73ae037b76d855015#diff-fb19e3a2727747b629809928773d964bc447218aca4bc27e4920424b79a495ebR209) call as it was stopping the DD agents.