### PR TITLE
Upgrade dependencies

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -54,7 +54,7 @@ dependencies:
   logs:
     mendix-logfilter:
       artifact: logs/mendix-logfilter-{{version}}.tar.gz
-      version: 0.0.2
+      version: 0.0.3
   mendix:
     mx-agent:
       artifact: mx-agent/mx-agent-v{{ version }}.jar

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -84,7 +84,7 @@ dependencies:
   newrelic:
     agent:
       artifact: newrelic/newrelic-java-{{ version }}.zip
-      version: 6.2.1
+      version: 6.5.4
   nginx:
     artifact: nginx_{{ version }}_linux_x64_cflinuxfs3_{{ commit }}.tgz
     commit: f0918d6b

--- a/tests/integration/test_logging.py
+++ b/tests/integration/test_logging.py
@@ -7,7 +7,7 @@ class TestCaseLogging(basetest.BaseTest):
     def setUp(self):
         super().setUp()
         self.stage_container(
-            "sample-6.2.0.mda",
+            "Mendix8.1.1.58432_StarterApp.mda",
             env_vars={
                 "LOGGING_CONFIG": json.dumps({"Jetty": "TRACE"}),
                 "LOG_RATELIMIT": 500,

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -83,7 +83,7 @@ class TestNewMetricsFlows(basetest.BaseTestWithPostgreSQL):
             env_vars={
                 "METRICS_INTERVAL": "10",
                 "BYPASS_LOGGREGATOR": "True",
-                "TRENDS_STORAGE_URL": "http://httpbin.org/post",
+                "TRENDS_STORAGE_URL": "http://postman-echo.com/post",
             },
         )
         self.start_container()

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -12,7 +12,9 @@ class TestCaseEmitMetrics(basetest.BaseTestWithPostgreSQL):
     # threads work as expected, just not that the metrics get to the right
     # destination.
     def test_read_metrics_in_logs(self):
-        self.stage_container("sample-6.2.0.mda", env_vars={"METRICS_INTERVAL": "10"})
+        self.stage_container(
+            "Mendix8.1.1.58432_StarterApp.mda", env_vars={"METRICS_INTERVAL": "10"}
+        )
         self.start_container()
 
         assert self.await_string_in_recent_logs("MENDIX-METRICS: ", 10)
@@ -23,7 +25,7 @@ class TestCaseEmitMetrics(basetest.BaseTestWithPostgreSQL):
 
     def test_free_apps_metrics(self):
         self.stage_container(
-            "sample-6.2.0.mda",
+            "Mendix8.1.1.58432_StarterApp.mda",
             env_vars={"METRICS_INTERVAL": "10", "PROFILE": "free"},
         )
         self.start_container()
@@ -34,10 +36,10 @@ class TestCaseEmitMetrics(basetest.BaseTestWithPostgreSQL):
         self.assert_string_in_recent_logs("named_user_sessions")
 
 
-class TestNewMetricsFlows(basetest.BaseTestWithPostgreSQL):
+class TestNewMetricsFlows(basetest.BaseTest):
     def test_fallback_flow_when_server_unreachable(self):
         self.stage_container(
-            "sample-6.2.0.mda",
+            "Mendix8.1.1.58432_StarterApp.mda",
             env_vars={
                 "METRICS_INTERVAL": "10",
                 "BYPASS_LOGGREGATOR": "True",
@@ -53,7 +55,7 @@ class TestNewMetricsFlows(basetest.BaseTestWithPostgreSQL):
 
     def test_fallback_when_no_url_set(self):
         self.stage_container(
-            "sample-6.2.0.mda",
+            "Mendix8.1.1.58432_StarterApp.mda",
             env_vars={"METRICS_INTERVAL": "10", "BYPASS_LOGGREGATOR": "True"},
         )
         self.start_container()
@@ -66,7 +68,7 @@ class TestNewMetricsFlows(basetest.BaseTestWithPostgreSQL):
 
     def test_fallback_with_bad_environment_variables(self):
         self.stage_container(
-            "sample-6.2.0.mda",
+            "Mendix8.1.1.58432_StarterApp.mda",
             env_vars={
                 "METRICS_INTERVAL": "10",
                 "BYPASS_LOGGREGATOR": "this will not coerce to a boolean",
@@ -79,7 +81,7 @@ class TestNewMetricsFlows(basetest.BaseTestWithPostgreSQL):
 
     def test_posting_metrics_works(self):
         self.stage_container(
-            "sample-6.2.0.mda",
+            "Mendix8.1.1.58432_StarterApp.mda",
             env_vars={
                 "METRICS_INTERVAL": "10",
                 "BYPASS_LOGGREGATOR": "True",


### PR DESCRIPTION
This PR upgrades the following dependencies
- Logs rate limiter : `mendix-logfilter`
- NewRelic java agent to address security vulnerabilities

> **Note**
>  NewRelic is currently not supported for apps deployed to Mendix Cloud