### PR TITLE
add nginx keepalive_timeout env to prevent race condition on gorouter

### DIFF
--- a/buildpack/core/nginx.py
+++ b/buildpack/core/nginx.py
@@ -104,6 +104,7 @@ def update_config():
         samesite_cookie_workaround_enabled=samesite_cookie_workaround_enabled,
         locations=_get_locations(),
         default_headers=_get_http_headers(),
+        nginx_keepalive_timeout=_get_nginx_keepalive_timeout(),
         nginx_port=str(util.get_nginx_port()),
         runtime_port=str(util.get_runtime_port()),
         admin_port=str(util.get_admin_port()),
@@ -134,6 +135,10 @@ def update_config():
     logging.debug("proxy_params configuration file written")
 
     _generate_password_file({"MxAdmin": security.get_m2ee_password()})
+
+
+def _get_nginx_keepalive_timeout():
+    return os.environ.get("NGINX_KEEPALIVE_TIMEOUT", "30")
 
 
 def _get_proxy_buffer_size():

--- a/etc/nginx/conf/nginx.conf.j2
+++ b/etc/nginx/conf/nginx.conf.j2
@@ -40,7 +40,7 @@ http {
     gzip_types text/plain text/css text/js text/xml text/javascript application/javascript application/x-javascript application/json application/xml application/xml+rss;
 
     tcp_nopush on;
-    keepalive_timeout 30;
+    keepalive_timeout {{ nginx_keepalive_timeout }};
     absolute_redirect off;
     server_tokens off;
 


### PR DESCRIPTION
the current default of 30 causes the same inconsistent 502's as https://community.pivotal.io/s/article/5004y00001buMQz1626802995951?language=en_US

and we need to set it to >90s so the gorouter is in charge of closing the connections
https://docs.cloudfoundry.org/adminguide/routing-keepalive.html

tl;dr

### Reason for this change:

With GoRouter's 90s keep alive enabled and the build pack's 30s it caused a intermittent EOF errors on the gorouter because it was trying to use an already closed connection...

```
{"log_level":3,"timestamp":"2023-05-24T09:26:55.408725231Z","message":"backend-endpoint-failed","source":"vcap.gorouter","data":{"route-endpoint":{"ApplicationId":"zzz","Addr":"zzz","Tags":{"app_id":"zzz","app_name":"xastest","component":"route-emitter","instance_id":"0","organization_id":"zzz","organization_name":"zzz","process_id":"zzz","process_instance_id":"zzz","process_type":"web","source_id":"zzz","space_id":"zzz","space_name":"zzz"},"RouteServiceUrl":""},"error":"EOF","attempt":1,"vcap_request_id":"zzz","retriable":false,"num-endpoints":1,"got-connection":true,"wrote-headers":true,"conn-reused":true,"dns-lookup-time":0,"dial-time":0,"tls-handshake-time":0}}
```

and on the client this header

```
'x-cf-routererror': 'endpoint_failure (EOF)'
```

Here are the two links as ref:

* Keepalive Considerations
https://docs.cloudfoundry.org/adminguide/routing-keepalive.html

* Similar behaviour on spring apps
https://community.pivotal.io/s/article/5004y00001buMQz1626802995951?language=en_US


### Testing this change:

Without any changes:

```
CF-nonp-4> cf push --no-start -b https://github.com/loadpi/cf-mendix-buildpack.git\#Add-nginx-keepalive-timeout -m 2G -k 4G -p SimpleAppRetrieves.mda xastest -d dev.mendixcloud.com
CF-nonp-4> cf start xastest
CF-nonp-4> cf ssh xastest
$ cat app/nginx/conf/nginx.conf | grep _timeout
    keepalive_timeout 30;
```

Then with the envvar

```
CF-nonp-4> cf set-env xastest NGINX_KEEPALIVE_TIMEOUT "100"
CF-nonp-4> cf restage xastest
CF-nonp-4> cf ssh xastest
$ cat app/nginx/conf/nginx.conf | grep _timeout
    keepalive_timeout 100;
```

This app starts posting to /xas twice every 10s and on long running tests with puppeteer the error's are not present when the nginx keepalive timeout is 100s


