### PR TITLE
ci: trigger job deploy also on releases/ branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Get current version
         id: get-current-version
         run: |
-          CURRENT_VERSION_TAG=$(git tag --list --sort=-version:refname "v*" | head -n 1)
+          CURRENT_VERSION_TAG=$(git tag --list --merged --sort=-version:refname "v*" | head -n 1)
           echo "::set-output name=current_version_tag::${CURRENT_VERSION_TAG}"
       - name: Auto-generate future version
         id: autogenerate-version

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
     types: [closed]
     branches:
       - master
+      - 'releases/**'
 
 jobs:
   pre:


### PR DESCRIPTION
If we want to support both 4.x and 5.x releases simultanuously, we need some way to trigger the releases github action on multiple branches. 

- This change proposes to create a branch called `releases/v4.x` off a49f32f4968e64e93a6975d72e74473878bdba3f
- Github action `deploy` is updated to work for both branches `master` and `releases/**`
- The Github action `build` step: `get-current-version` now lists the latest tag that is merged in that branch with [--merged](https://git-scm.com/docs/git-tag). So it won't find the 5.x tag in the 4.x tree.
