### PR TITLE
Db 2086 send dependencies json in client config call release 4.x

### DIFF
--- a/buildpack/databroker/business_events.py
+++ b/buildpack/databroker/business_events.py
@@ -45,7 +45,6 @@ def _put_client_config(url, auth_token, version, dependencies_json_str):
             backoff_factor=0.1,
             status_forcelist=[ 500, 502, 503, 504 ])
     adapter = HTTPAdapter(max_retries=retries)
-    session.mount('http://', adapter)
     session.mount('https://', adapter)
 
     resp = session.put(

--- a/buildpack/databroker/business_events.py
+++ b/buildpack/databroker/business_events.py
@@ -41,19 +41,15 @@ def _put_client_config(url, auth_token, version, dependencies_json_str):
     }
 
     session = requests.Session()
-    retries = Retry(total=2,
-            backoff_factor=0.1,
-            status_forcelist=[ 500, 502, 503, 504 ])
+    retries = Retry(total=2, backoff_factor=0.1, status_forcelist=[500, 502, 503, 504])
     adapter = HTTPAdapter(max_retries=retries)
-    session.mount('https://', adapter)
+    session.mount("https://", adapter)
 
     resp = session.put(
         url=url,
         headers=headers,
-        json={
-            "dependencies": dependencies_json_str
-        },
-        timeout=30
+        json={"dependencies": dependencies_json_str},
+        timeout=30,
     )
     resp.raise_for_status()
     return resp.text
@@ -75,10 +71,9 @@ def _read_dependencies_json_as_str():
         with open(file_path) as f:
             return f.read()
     except FileNotFoundError:
-        logging.error(
-            "Business Events: dependencies.json not found %s", file_path
-        )
+        logging.error("Business Events: dependencies.json not found %s", file_path)
         raise
+
 
 def _get_config(vcap_services, existing_constants):
     be_config = {}

--- a/buildpack/databroker/business_events.py
+++ b/buildpack/databroker/business_events.py
@@ -6,6 +6,7 @@ Extract Business Events configuration from vcap services and create mx constants
 import os
 import logging
 import requests
+from requests.adapters import HTTPAdapter, Retry
 
 from buildpack import util
 
@@ -39,7 +40,15 @@ def _put_client_config(url, auth_token, version, dependencies_json_str):
         "X-Version": version,
     }
 
-    resp = requests.put(
+    session = requests.Session()
+    retries = Retry(total=2,
+            backoff_factor=0.1,
+            status_forcelist=[ 500, 502, 503, 504 ])
+    adapter = HTTPAdapter(max_retries=retries)
+    session.mount('http://', adapter)
+    session.mount('https://', adapter)
+
+    resp = session.put(
         url=url,
         headers=headers,
         json={

--- a/buildpack/databroker/business_events.py
+++ b/buildpack/databroker/business_events.py
@@ -105,7 +105,7 @@ def _get_config(vcap_services, existing_constants):
                         client_config = _put_client_config(
                             kafka_creds.get(CLIENT_CONFIG_URL_KEY, ""),
                             auth_token,
-                            "2",
+                            "1",
                             _read_dependencies_json_as_str(),
                         )
                         be_config[

--- a/tests/unit/test_databroker_business_events.py
+++ b/tests/unit/test_databroker_business_events.py
@@ -166,13 +166,17 @@ class TestDataBrokerBusinessEvents(unittest.TestCase):
 
     def _verify_vcap_info(self, is_apply_limits_present=True):
         with mock.patch(
-            "buildpack.databroker.business_events._get_client_config",
+            "buildpack.databroker.business_events._put_client_config",
             mock.MagicMock(return_value=self.expected_client_config),
-        ):
+        ), mock.patch(
+            "buildpack.databroker.business_events._read_dependencies_json",
+            mock.MagicMock(return_value={})) as mock_read_dependencies_json:
             business_events_cfg = business_events._get_config(
                 util.get_vcap_services_data(),
                 self.module_constants_with_metrics,
             )
+            mock_read_dependencies_json.assert_called_once()
+
         prefix = business_events.CONSTANTS_PREFIX
 
         assert business_events_cfg[f"{prefix}.ServerUrl"] == self.server_url

--- a/tests/unit/test_databroker_business_events.py
+++ b/tests/unit/test_databroker_business_events.py
@@ -169,13 +169,13 @@ class TestDataBrokerBusinessEvents(unittest.TestCase):
             "buildpack.databroker.business_events._put_client_config",
             mock.MagicMock(return_value=self.expected_client_config),
         ), mock.patch(
-            "buildpack.databroker.business_events._read_dependencies_json",
-            mock.MagicMock(return_value={})) as mock_read_dependencies_json:
+            "buildpack.databroker.business_events._read_dependencies_json_as_str",
+            mock.MagicMock(return_value="")) as mock_read_dependencies_json_as_str:
             business_events_cfg = business_events._get_config(
                 util.get_vcap_services_data(),
                 self.module_constants_with_metrics,
             )
-            mock_read_dependencies_json.assert_called_once()
+            mock_read_dependencies_json_as_str.assert_called_once()
 
         prefix = business_events.CONSTANTS_PREFIX
 

--- a/tests/unit/test_databroker_business_events.py
+++ b/tests/unit/test_databroker_business_events.py
@@ -170,7 +170,8 @@ class TestDataBrokerBusinessEvents(unittest.TestCase):
             mock.MagicMock(return_value=self.expected_client_config),
         ), mock.patch(
             "buildpack.databroker.business_events._read_dependencies_json_as_str",
-            mock.MagicMock(return_value="")) as mock_read_dependencies_json_as_str:
+            mock.MagicMock(return_value=""),
+        ) as mock_read_dependencies_json_as_str:
             business_events_cfg = business_events._get_config(
                 util.get_vcap_services_data(),
                 self.module_constants_with_metrics,


### PR DESCRIPTION
the client-config request to the cf-kafka-broker is updated to a PUT instead of a GET that excepts the dependencies.json file in the body. The start is modified to read this file and send it in the request.
note: shouldn't be merged before the cf-kafka-broker changes are live