### PR TITLE
Tweak metrics payload and publish interval for runtime user login metrics

### DIFF
--- a/etc/telegraf/telegraf.toml.j2
+++ b/etc/telegraf/telegraf.toml.j2
@@ -440,8 +440,8 @@
   data_format = "json"
   json_timestamp_units = "1ns"
 
-  # tagexlude drops any non-relevant tags
-  tagexclude = ["host"]
+  # include only relevant tags
+  taginclude = ["anonymous_upgrade", "user", "app_name", "instance_index"]
 
   ## Additional HTTP headers
   [outputs.http.headers]


### PR DESCRIPTION
Changes in the MR mainly tweaks the payload published to the backend trends stack for `mx.runtime.user.login` metrics. This metric is not used in the Mendix Trends graphs.

- Payload would contain only relevant tags required by the backend stack. This should help reduce the payload size.
- Publish interval bumped from `10s` to `1m`. As this metric is used for internal analysis, better to aggregate the metric over a bigger time window and publish less frequently to the backend stack.