### PR TITLE
Added Non Mendix Public cloud Flag to set metric type

### DIFF
--- a/buildpack/telemetry/metrics.py
+++ b/buildpack/telemetry/metrics.py
@@ -110,12 +110,12 @@ def micrometer_metrics_enabled(runtime_version):
     """Check for metrics from micrometer."""
     logging.info("checking is micrometer metrics enabled")
     micrometer_enabled=False
-    if(_micrometer_runtime_requirement(runtime_version))
+    if(_micrometer_runtime_requirement(runtime_version)):
         logging.info("satisfies micrometer runtime requirement")
-        if(bool(get_micrometer_metrics_url()))
+        if(bool(get_micrometer_metrics_url())):
             logging.info("Found micrometer metrics url configured")
             micrometer_enabled = True
-        elif(strtobool(os.getenv("NON_MENDIX_PUBLIC_CLOUD","false")))
+        elif(strtobool(os.getenv("NON_MENDIX_PUBLIC_CLOUD","false"))):
             logging.info("micrometer for non mendix public cloud")
             micrometer_enabled =  True
     return micrometer_enabled

--- a/buildpack/telemetry/metrics.py
+++ b/buildpack/telemetry/metrics.py
@@ -108,9 +108,18 @@ def _micrometer_runtime_requirement(runtime_version):
 
 def micrometer_metrics_enabled(runtime_version):
     """Check for metrics from micrometer."""
-    return bool(get_micrometer_metrics_url()) and _micrometer_runtime_requirement(
-        runtime_version
-    )
+    logging.info("checking is micrometer metrics enabled")
+    micrometer_enabled=False
+    if(_micrometer_runtime_requirement(runtime_version))
+        logging.info("satisfies micrometer runtime requirement")
+        if(bool(get_micrometer_metrics_url()))
+            logging.info("Found micrometer metrics url configured")
+            micrometer_enabled = True
+        elif(strtobool(os.getenv("NON_MENDIX_PUBLIC_CLOUD","false")))
+            logging.info("micrometer for non mendix public cloud")
+            micrometer_enabled =  True
+    return micrometer_enabled
+    
 
 
 def configure_metrics_registry(m2ee):


### PR DESCRIPTION
Added flag "NON_MENDIX_PUBLIC_CLOUD" to decide whether micrometer metrics is enabled. This is required because metrics url is not set on SAP BTP so need another check to set it to micrometer for Mendix runtime > 9.7