### PR TITLE
Upgrade datadog integration

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -23,7 +23,7 @@ dependencies:
       version: 4.37.0
     trace-agent:
       artifact: datadog/dd-java-agent-{{ version }}.jar
-      version: 0.101.0
+      version: 1.27.0
   dynatrace:
     agent:
       artifact: "{{ url }}/e/{{ environment }}/api/v1/deployment/installer/agent/unix/paas/latest?include=java&bitness=64&Api-Token={{ token }}"

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -20,7 +20,7 @@ dependencies:
     buildpack:
       alias: cf-datadog-sidecar
       artifact: datadog/datadog-cloudfoundry-buildpack-{{ version }}.zip
-      version: 4.33.0
+      version: 4.37.0
     trace-agent:
       artifact: datadog/dd-java-agent-{{ version }}.jar
       version: 0.101.0
@@ -92,6 +92,11 @@ dependencies:
     fs: cflinuxfs4
     cpe: cpe:2.3:a:f5:nginx:{{ version }}:*:*:*:*:*:*:*
     version: 1.22.1
+  ruby:
+    artifact: ruby/ruby_{{ version }}_linux_x64_{{ fs }}_{{ commit }}.tgz
+    commit: 5fed98f8
+    fs: cflinuxfs4
+    version: 3.2.2
   telegraf:
     agent:
       artifact: telegraf/telegraf-{{ version }}_linux_amd64.tar.gz

--- a/tests/integration/test_datadog.py
+++ b/tests/integration/test_datadog.py
@@ -59,8 +59,8 @@ class TestCaseDeployWithDatadog(basetest.BaseTestWithPostgreSQL):
         logsubscribers = json.loads(logsubscribers_json.text)
         self.assertTrue("DatadogSubscriber" in logsubscribers["feedback"])
 
-    def test_datadog_mx7(self):
-        self._test_datadog("BuildpackTestApp-mx-7-16.mda")
-
     def test_datadog_mx8(self):
         self._test_datadog("Mendix8.1.1.58432_StarterApp.mda")
+
+    def test_datadog_mx9(self):
+        self._test_datadog("BuildpackTestApp-mx9-7.mda")


### PR DESCRIPTION
- Upgrade `datadog-cloudfoundry-buildpack` to 4.37.0
- Upgrade datadog trace-agent for java (`dd-java-agent`) to 1.27.0