### PR TITLE
feat: add MTS support for Mendix 10.6.x

### DIFF
--- a/buildpack/core/runtime.py
+++ b/buildpack/core/runtime.py
@@ -52,6 +52,8 @@ def is_version_maintained(version):
         return True
     if version.major == 9 and version.minor == 24:
         return True
+    if version.major == 10 and version.minor == 6:
+        return True
     return False
 
 

--- a/tests/unit/test_deprecations.py
+++ b/tests/unit/test_deprecations.py
@@ -8,6 +8,7 @@ from lib.m2ee.version import MXVersion
 # - Mendix 7: 7.23.x (LTS)
 # - Mendix 8: 8.18.x (LTS)
 # - Mendix 9: 9.6.x (MTS), 9.12.x (MTS), 9.18.x (MTS), 9.24.x (LTS)
+# - Mendix 10: 10.6.x (MTS)
 
 
 class TestCaseMxImplemented(TestCase):
@@ -47,3 +48,9 @@ class TestCaseMxMaintained(TestCase):
 
     def test_mx9_not_maintained(self):
         assert not runtime.is_version_maintained(MXVersion("9.16"))
+
+    def test_mx10_maintained(self):
+        assert runtime.is_version_maintained(MXVersion("10.6.1"))
+
+    def test_mx10_not_maintained(self):
+        assert not runtime.is_version_maintained(MXVersion("10.5.1"))


### PR DESCRIPTION
I noticed this in the logs of my Mendix 10.6.3 app:
```
[..]
INFO: Preflight check on Mendix version [10.6.3.26585] and stack [cflinuxfs4]...
INFO: Mendix [10.6] is not maintained. Please use a medium- or long-term supported Mendix version to easily receive fixes (https://docs.mendix.com/releasenotes/studio-pro/lts-mts).
[..]
```

According to https://docs.mendix.com/releasenotes/studio-pro/lts-mts this is not true. This PR should solve this.