### PR TITLE
Pref.xml generation change for SAP or non-mendix cloud.

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,8 @@ This buildpack provides the [Adoptium](https://adoptium.net/) JDK and JRE.
 
 ### Java Version
 
-The buildpack will automatically determine the Java version to use based on the runtime version of the app being deployed. The default Java version is 8. For Mendix 8 and above, the default Java version is 11.
+The buildpack will automatically determine the Java version from metadata(it will have JavaVersion as json attribute). The default Java version is 8. For Mendix 8 and above, the default Java version is 11.
+Metadata JavaVersion attribute will have these values "11", "17" or in the future "21".
 
 We do not recommend overriding the Java version for the buildpack. However, for cases where this is required, the `JAVA_VERSION` variable can be used to override the version number.
 

--- a/buildpack/core/runtime.py
+++ b/buildpack/core/runtime.py
@@ -7,6 +7,7 @@ import shutil
 import sqlite3
 import subprocess
 import time
+from distutils.util import strtobool
 
 import backoff
 from buildpack import util
@@ -172,6 +173,14 @@ def _activate_license():
   <entry key="id" value="{{LICENSE_ID}}"/>
   <entry key="license_key" value="{{LICENSE_KEY}}"/>
 </map>"""
+
+    if(strtobool(os.environ.get("MXRUNTIME_License.UseLicenseServer","false"))):
+        prefs_template = """<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+        <!DOCTYPE map SYSTEM "http://java.sun.com/dtd/preferences.dtd">
+        <map MAP_XML_VERSION="1.0">
+          <entry key="id2" value="{{LICENSE_ID}}"/>
+          <entry key="license_key2" value="{{LICENSE_KEY}}"/>
+        </map>"""
 
     license_key = os.environ.get(
         "FORCED_LICENSE_KEY", os.environ.get("LICENSE_KEY", None)

--- a/buildpack/core/runtime.py
+++ b/buildpack/core/runtime.py
@@ -44,13 +44,9 @@ def is_version_maintained(version):
         return True
     if version.major == 8 and version.minor == 18:
         return True
-    if version.major == 9 and version.minor == 6:
-        return True
-    if version.major == 9 and version.minor == 12:
-        return True
-    if version.major == 9 and version.minor == 18:
-        return True
     if version.major == 9 and version.minor == 24:
+        return True
+    if version.major == 10 and version.minor == 6:
         return True
     return False
 
@@ -104,7 +100,7 @@ def get_metadata_value(key, build_path=BASE_PATH):
         with open(file_name) as file_handle:
             data = json.loads(file_handle.read())
             return data[key]
-    except IOError:
+    except (IOError, KeyError):
         return None
 
 
@@ -113,7 +109,7 @@ def get_runtime_version(build_path=BASE_PATH):
     if result is None:
         logging.debug(
             "Cannot retrieve runtime version %s from metadata file, "
-            "falling back to project file",
+            "falling back to project file ",
             result,
         )
         mpr = util.get_mpr_file_from_dir(build_path)

--- a/buildpack/stage.py
+++ b/buildpack/stage.py
@@ -163,7 +163,7 @@ if __name__ == "__main__":
     )
 
     runtime_version = runtime.get_runtime_version(BUILD_DIR)
-    JAVA_VERSION = java.get_java_major_version(runtime_version)
+    JAVA_VERSION = java.get_java_major_version(runtime_version, BUILD_DIR)
 
     try:
         preflight_check(runtime_version)

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -51,6 +51,8 @@ dependencies:
       version:
         - "8": 8u392
         - "11": 11.0.21
+        - "17": 17.0.9
+        - "21": 21.0.2
   logs:
     mendix-logfilter:
       artifact: logs/mendix-logfilter-{{version}}.tar.gz

--- a/tests/unit/test_deprecations.py
+++ b/tests/unit/test_deprecations.py
@@ -40,10 +40,15 @@ class TestCaseMxMaintained(TestCase):
         assert not runtime.is_version_maintained(MXVersion("8.17"))
 
     def test_mx9_maintained(self):
-        assert runtime.is_version_maintained(MXVersion("9.6.9"))
-        assert runtime.is_version_maintained(MXVersion("9.12.1"))
-        assert runtime.is_version_maintained(MXVersion("9.18.3"))
         assert runtime.is_version_maintained(MXVersion("9.24.0"))
 
     def test_mx9_not_maintained(self):
-        assert not runtime.is_version_maintained(MXVersion("9.16"))
+        assert not runtime.is_version_maintained(MXVersion("9.18"))
+        assert not runtime.is_version_maintained(MXVersion("9.6.9"))
+        assert not runtime.is_version_maintained(MXVersion("9.12.1"))
+
+    def test_mx10_maintained(self):
+        assert runtime.is_version_maintained(MXVersion("10.6.1"))
+
+    def test_mx10_not_maintained(self):
+        assert not runtime.is_version_maintained(MXVersion("10.5.1"))


### PR DESCRIPTION
We have added a small code change, where incase if there is any SAP cloud based or non-mendix cloud license comes, then would update pref.xml file with valid credentials ID and Key.