### PR TITLE
Bump dependencies to resolve Dependabot alerts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10.13
+          python-version: 3.10.14
           cache: pip
       - name: Install Python requirements
         run: make install_requirements

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,21 +38,12 @@ jobs:
           path: dist
       - name: Create Github release
         id: create-release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/heads/master')
         with:
+          name: "${{ needs.build.outputs.version_tag }}: ${{ github.event.pull_request.title }}"
           tag_name: ${{ needs.build.outputs.version_tag }}
-          release_name: "${{ needs.build.outputs.version_tag }}: ${{ github.event.pull_request.title }}"
           body: ${{ github.event.pull_request.body }}
-          draft: true
-          prerelease: false
-      - name: Upload release asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: dist/cf-mendix-buildpack.zip
-          asset_name: cf-mendix-buildpack.zip
-          asset_content_type: application/zip
+          files: |
+            dist/cf-mendix-buildpack.zip
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.10.13
+        python-version: 3.10.14
         cache: pip
     - name: Install Python requirements
       run: make install_requirements

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ TEST_FILES ?= tests/integration/test_*.py
 VERSION ?= $(shell git tag --list --sort=-version:refname "v*" | head -n 1)
 COMMIT ?= $(shell git rev-parse --short HEAD)
 
-PIP_TOOLS_VERSION ?= 7.4.0
-PIP_VERSION ?= 24.0
+PIP_TOOLS_VERSION ?= 7.4.1
+PIP_VERSION ?= 24.1.2
 PYTHON_PLATFORM ?= manylinux2014_x86_64
 PYTHON_VERSION ?= 310
 

--- a/bin/install-python
+++ b/bin/install-python
@@ -39,7 +39,7 @@ function setup_online(){
   install_dir="$2"
   buildpack_dir="$3"
 
-  curl -Ls "https://cdn.mendix.com/tmp-buildpacks/python_3.10.13_linux_x64_cflinuxfs4_04ab8c1b.tgz" | tar -xzf - -C "$install_dir"
+  curl -Ls "https://cdn.mendix.com/mx-buildpack/python/python_3.10.14_linux_x64_cflinuxfs4_dda5228c.tgz" | tar -xzf - -C "$install_dir"
 }
 
 function get_python_from_manifest() {

--- a/dependencies-stage.yml
+++ b/dependencies-stage.yml
@@ -1,8 +1,9 @@
 ---
+# https://github.com/cloudfoundry/python-buildpack/blob/master/manifest.yml
 - name: python
-  version: 3.10.13
-  uri: https://cdn.mendix.com/tmp-buildpacks/python_3.10.13_linux_x64_cflinuxfs4_04ab8c1b.tgz 
-  sha256: 04ab8c1b6b0d1f8fd8a03d932bf8cc6744843ad12bb5e801784b7ff470aa7401
+  version: 3.10.14
+  uri: https://cdn.mendix.com/mx-buildpack/python/python_3.10.14_linux_x64_cflinuxfs4_dda5228c.tgz
+  sha256: dda5228c36196f8a7346767ad9c9ac774ec270aa55065beb8d3d052d652b9120
   cf_stacks:
   - cflinuxfs4
-  source_sha256: 698ec55234c1363bd813b460ed53b0f108877c7a133d48bde9a50a1eb57b7e65
+  source_sha256: cefea32d3be89c02436711c95a45c7f8e880105514b78680c14fe76f5709a0f6

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -51,9 +51,9 @@ dependencies:
       vendor: Adoptium
       version:
         - "8": 8u392
-        - "11": 11.0.21
+        - "11": 11.0.23
         - "17": 17.0.9
-        - "21": 21.0.2
+        - "21": 21.0.3
   logs:
     mendix-logfilter:
       artifact: logs/mendix-logfilter-{{version}}.tar.gz

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 backoff==2.2.1
-certifi==2024.6.2
+certifi==2024.7.4
 cryptography==42.0.8
 distro==1.9.0
 httplib2==0.22.0

--- a/requirements.in
+++ b/requirements.in
@@ -8,4 +8,4 @@ omegaconf==2.3.0
 psycopg2-binary==2.9.9
 pyyaml==6.0.1
 requests==2.32.3
-urllib3==2.2.1
+urllib3==2.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ antlr4-python3-runtime==4.9.3
     # via omegaconf
 backoff==2.2.1
     # via -r requirements.in
-certifi==2024.6.2
+certifi==2024.7.4
     # via
     #   -r requirements.in
     #   requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ pyyaml==6.0.1
     #   omegaconf
 requests==2.32.3
     # via -r requirements.in
-urllib3==2.2.1
+urllib3==2.2.2
     # via
     #   -r requirements.in
     #   requests


### PR DESCRIPTION
Security updates:

* Update Python to 3.10.14
* Update certifi to 2024.7.4 (drops GlobalTrust)
* Update urllib3 to 2.2.2

Minor updates:

* Update pip-tools to 7.4.1
* Update pip to 24.2
* Update Java 11 to 11.0.23
* Update Java 21 to 21.0.3

Pipeline updates:

* Use maintained GitHub Actions for our release process
* Use proper Mendix CDN location for Python