### PR TITLE
feat(nginx): allow to block web requests based on the IP addresses

### DIFF
--- a/etc/nginx/conf/nginx.conf.j2
+++ b/etc/nginx/conf/nginx.conf.j2
@@ -54,6 +54,13 @@ http {
         keepalive 8;
     }
 
+    {% if ip_addresses_to_block %}
+    # mark bad IPs
+    {% for cidr in ip_addresses_to_block %}
+    deny {{cidr}};
+    {% endfor %}
+    {% endif %}
+
     server {
         listen {{ nginx_port }};
         server_name _;


### PR DESCRIPTION
Allow to block web requests based on the IP addresses. The IP addresses must be provided in a comma-separated list of IP addresses (CIDR notation) in `NGINX_BLOCK_IP_ADDRESSES` environment variable, e.g. `NGINX_BLOCK_IP_ADDRESSES=10.16.255.0/24,1.2.3.4/24`.