### PR TITLE
Bump nginx from 1.22.1 to 1.26.1

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -89,10 +89,10 @@ dependencies:
       version: 8.6.0
   nginx:
     artifact: nginx_{{ version }}_linux_x64_{{ fs }}_{{ commit }}.tgz
-    commit: 909b06a9
+    commit: b1316f75
     fs: cflinuxfs4
     cpe: cpe:2.3:a:f5:nginx:{{ version }}:*:*:*:*:*:*:*
-    version: 1.22.1
+    version: 1.26.1
   ruby:
     artifact: ruby/ruby_{{ version }}_linux_x64_{{ fs }}_{{ commit }}.tgz
     commit: 5fed98f8


### PR DESCRIPTION
Upgrade conatiner's nginx from 1.22.1 to 1.26.1

Change Log: https://nginx.org/en/CHANGES-1.26