### PR TITLE
Upgrade datadog agents to the latest versions

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -21,10 +21,10 @@ dependencies:
     buildpack:
       alias: cf-datadog-sidecar
       artifact: datadog/datadog-cloudfoundry-buildpack-{{ version }}.zip
-      version: 4.37.0
+      version: 4.42.0
     trace-agent:
       artifact: datadog/dd-java-agent-{{ version }}.jar
-      version: 1.27.0
+      version: 1.45.2
   dynatrace:
     agent:
       artifact: "{{ url }}/e/{{ environment }}/api/v1/deployment/installer/agent/unix/paas/latest?include=java&bitness=64&Api-Token={{ token }}"

--- a/etc/m2ee/m2ee.yaml
+++ b/etc/m2ee/m2ee.yaml
@@ -22,9 +22,9 @@ m2ee:
   javaopts:
     [
       "-Dfile.encoding=UTF-8",
-      "-Djava.io.tmpdir=BUILD_PATH/data/tmp",
-      "-XX:OnError=kill -s USR1 PYTHONPID",
-      "-XX:OnOutOfMemoryError=kill -s USR2 PYTHONPID",
+      "-Djava.io.tmpdir=/tmp",
+      "-XX:OnError=BUILD_PATH/.local/scripts/on_error.sh",
+      "-XX:OnOutOfMemoryError=BUILD_PATH/.local/scripts/on_out_of_memory_error.sh",
     ]
 
   jetty:

--- a/etc/scripts/on_error.sh
+++ b/etc/scripts/on_error.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+kill -s USR1 PYTHONPID

--- a/etc/scripts/on_out_of_memory_error.sh
+++ b/etc/scripts/on_out_of_memory_error.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+kill -s USR2 PYTHONPID


### PR DESCRIPTION
- Upgrade datadog-cloudfoundry-buildpack version to `4.42.0`
- Upgrade dd-java-agent (trace agent) version to `1.45.2`
- Move on error actions to separate shell scripts
      * We update java opts for `OnError` and `OnOutOfMemoryError` handling
      * New dd agent expect these commands to be in shell scripts (instead of defining them directly)
      * So, we moved those to separate shell scripts


