### PR TITLE
Update nginx.conf.j2

### DIFF
--- a/etc/nginx/conf/nginx.conf.j2
+++ b/etc/nginx/conf/nginx.conf.j2
@@ -37,7 +37,7 @@ http {
     gzip_min_length 1100;
     gzip_buffers 16 8k;
     gzip_proxied any;
-    gzip_types text/plain text/css text/js text/xml text/javascript application/javascript application/x-javascript application/json application/xml application/xml+rss;
+    gzip_types text/plain text/css text/js text/xml text/javascript application/javascript application/x-javascript application/json application/xml application/xml+rss application/wasm;
 
     tcp_nopush on;
     keepalive_timeout {{ nginx_keepalive_timeout }};


### PR DESCRIPTION
A customer noted that the sqlite wasm file used for PWAs is not gzipped.

Add application/wasm to gzip_types in nginx.conf.j2