### PR TITLE
fix: revert java tempdir change

### DIFF
--- a/etc/m2ee/m2ee.yaml
+++ b/etc/m2ee/m2ee.yaml
@@ -22,7 +22,7 @@ m2ee:
   javaopts:
     [
       "-Dfile.encoding=UTF-8",
-      "-Djava.io.tmpdir=/tmp",
+      "-Djava.io.tmpdir=BUILD_PATH/data/tmp",
       "-XX:OnError=BUILD_PATH/.local/scripts/on_error.sh",
       "-XX:OnOutOfMemoryError=BUILD_PATH/.local/scripts/on_out_of_memory_error.sh",
     ]


### PR DESCRIPTION
revert java tempdir change that was introduced in [Release 2025-02-20 #855](https://github.com/mendix/cf-mendix-buildpack/pull/855)
