### PR TITLE
Fix CVE-2026-25645 and CVE-2026-34073 by upgrading requests 

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,5 +7,5 @@ jinja2==3.1.6
 omegaconf==2.3.0
 psycopg2-binary==2.9.10
 pyyaml==6.0.2
-requests==2.32.5
+requests==2.33.1
 urllib3==2.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ pyyaml==6.0.2
     # via
     #   -r requirements.in
     #   omegaconf
-requests==2.32.5
+requests==2.33.1
     # via -r requirements.in
 typing-extensions==4.15.0
     # via cryptography


### PR DESCRIPTION

Updated requests from 2.32.5 to 2.33.1 to address CVE-2026-25645. 