### PR TITLE
Support static files caching

### DIFF
--- a/etc/nginx/conf/nginx.conf.j2
+++ b/etc/nginx/conf/nginx.conf.j2
@@ -97,7 +97,7 @@ http {
         {{ location.body }}
         }
         {% else %}
-            if ($request_uri ~ ^/(.*\.(css|js)|forms/.*|img/.*|pages/.*|mxclientsystem/images/.*)\?[0-9]+$) {
+            if ($request_uri ~ ^/((.*\.(css|js)|forms/.*|img/.*|pages/.*|mxclientsystem/images/.*)\?[0-9]+|dist/chunks/.*\.js|.*\.(woff2?|ttf|otf|eot))$) {
                     expires 1y;
             }
         {% if location.path == "/" %}


### PR DESCRIPTION
In this PR, we change the regex for cacheable files to support static files caching.
In 11.12 we started caching modern client files so we moved all the client static chunks into `dist/chunks`.
We also started caching app icons and fonts.

