### PR TITLE
ecurity: upgrade nginx 1.26.1 → 1.30.3

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -79,10 +79,10 @@ dependencies:
       version: 8.24.0
   nginx:
     artifact: nginx_{{ version }}_linux_x64_{{ fs }}_{{ commit }}.tgz
-    commit: b1316f75
+    commit: 7930a869
     fs: cflinuxfs4
     cpe: cpe:2.3:a:f5:nginx:{{ version }}:*:*:*:*:*:*:*
-    version: 1.26.1
+    version: 1.30.3
   ruby:
     artifact: ruby/ruby_{{ version }}_linux_x64_{{ fs }}_{{ commit }}.tgz
     commit: 5fed98f8


### PR DESCRIPTION
Upgrades nginx to 1.30.3 to fix:
- CVE-2025-23419 (Medium) — SSL session reuse bypasses client cert auth
- CVE-2026-42945 (High, CVSS 8.1) — Heap buffer overflow in rewrite module

Binary manually uploaded to s3://mx-cdn/mx-buildpack/ from CloudFoundry buildpacks.
SHA256: 7930a869ea8f9f3e38b0ad30cb7e788ec0897bf159f818c63eafb18ce48272a6